### PR TITLE
MODUIMP-13 - Support loading of Delivery request fields via mod-user-import

### DIFF
--- a/ramls/examples/userdataimportCollection.sample
+++ b/ramls/examples/userdataimportCollection.sample
@@ -21,6 +21,13 @@
       },
       "customFields": {
         "scope_1": "Design"
+      },
+      "requestPreference": {
+        "holdShelf": true,
+        "delivery": true,
+        "defaultServicePointId": "00000000-0000-1000-a000-000000000000",
+        "defaultDeliveryAddressTypeId": "11111111-1111-1111-b111-111111111111",
+        "fulfillment": "Delivery"
       }
     }
   ],

--- a/ramls/schemas/user-import-request-preference.json
+++ b/ramls/schemas/user-import-request-preference.json
@@ -5,13 +5,13 @@
   "properties": {
     "id": {
       "description": "Unique request preference ID",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-      "type": "string"
+      "type": "string",
+      "$ref": "../raml-util/schemas/uuid.schema"
     },
     "userId": {
       "description": "UUID of user associated with this request preference",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-      "type": "string"
+      "type": "string",
+      "$ref": "../raml-util/schemas/uuid.schema"
     },
     "holdShelf": {
       "description": "Whether 'Hold Shelf' option is available to the user.",
@@ -27,13 +27,13 @@
     },
     "defaultServicePointId": {
       "description": "UUID of default service point for 'Hold Shelf' option",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-      "type": "string"
+      "type": "string",
+      "$ref": "../raml-util/schemas/uuid.schema"
     },
     "defaultDeliveryAddressTypeId": {
       "description": "UUID of user's address type",
-      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
-      "type": "string"
+      "type": "string",
+      "$ref": "../raml-util/schemas/uuid.schema"
     },
     "fulfillment": {
       "description": "Preferred fulfillment type. Possible values are 'Delivery', 'Hold Shelf'",

--- a/ramls/schemas/user-import-request-preference.json
+++ b/ramls/schemas/user-import-request-preference.json
@@ -1,0 +1,55 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "type": "object",
+  "description": "Request preference schema",
+  "properties": {
+    "id": {
+      "description": "Unique request preference ID",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "userId": {
+      "description": "UUID of user associated with this request preference",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "holdShelf": {
+      "description": "Whether 'Hold Shelf' option is available to the user.",
+      "type": "boolean",
+      "enum": [true],
+      "example": true
+    },
+    "delivery": {
+      "description": "Whether 'Delivery' option is available to the user.",
+      "type": "boolean",
+      "default": false,
+      "example": false
+    },
+    "defaultServicePointId": {
+      "description": "UUID of default service point for 'Hold Shelf' option",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "defaultDeliveryAddressTypeId": {
+      "description": "UUID of user's address type",
+      "pattern": "^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$",
+      "type": "string"
+    },
+    "fulfillment": {
+      "description": "Preferred fulfillment type. Possible values are 'Delivery', 'Hold Shelf'",
+      "type": "string",
+      "enum":["Delivery", "Hold Shelf"],
+      "example": "Delivery"
+    },
+    "metadata": {
+      "description": "Metadata about creation and changes to request preference",
+      "$ref": "../raml-util/schemas/metadata.schema",
+      "readonly": true
+    }
+  },
+  "additionalProperties": false,
+  "required": [
+    "holdShelf",
+    "delivery"
+  ]
+}

--- a/ramls/schemas/userdataimport.json
+++ b/ramls/schemas/userdataimport.json
@@ -165,6 +165,11 @@
       "description": "Object that contains custom field",
       "type": "object",
       "additionalProperties": true
+    },
+    "requestPreference": {
+      "description": "User request preferences",
+      "type": "object",
+      "$ref": "user-import-request-preference.json"
     }
   },
   "additionalProperties": false,

--- a/src/main/java/org/folio/rest/impl/UserImportAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserImportAPI.java
@@ -4,6 +4,7 @@ import static org.folio.rest.util.AddressTypeManager.getAddressTypes;
 import static org.folio.rest.util.HttpClientUtil.createHeaders;
 import static org.folio.rest.util.HttpClientUtil.getOkapiUrl;
 import static org.folio.rest.util.PatronGroupManager.getPatronGroups;
+import static org.folio.rest.util.ServicePointsService.getServicePoints;
 import static org.folio.rest.util.UserDataUtil.extractExistingUsers;
 import static org.folio.rest.util.UserDataUtil.updateExistingUserWithIncomingFields;
 import static org.folio.rest.util.UserDataUtil.updateUserData;
@@ -12,8 +13,6 @@ import static org.folio.rest.util.UserImportAPIConstants.ERROR_MESSAGE;
 import static org.folio.rest.util.UserImportAPIConstants.FAILED_TO_ADD_PERMISSIONS_FOR_USER_WITH_EXTERNAL_SYSTEM_ID;
 import static org.folio.rest.util.UserImportAPIConstants.FAILED_TO_CREATE_NEW_USER_WITH_EXTERNAL_SYSTEM_ID;
 import static org.folio.rest.util.UserImportAPIConstants.FAILED_TO_IMPORT_USERS;
-import static org.folio.rest.util.UserImportAPIConstants.FAILED_TO_LIST_ADDRESS_TYPES;
-import static org.folio.rest.util.UserImportAPIConstants.FAILED_TO_LIST_PATRON_GROUPS;
 import static org.folio.rest.util.UserImportAPIConstants.FAILED_TO_PROCESS_USERS;
 import static org.folio.rest.util.UserImportAPIConstants.FAILED_TO_PROCESS_USER_SEARCH_RESPONSE;
 import static org.folio.rest.util.UserImportAPIConstants.FAILED_TO_PROCESS_USER_SEARCH_RESULT;
@@ -28,7 +27,9 @@ import static org.folio.rest.util.UserImportAPIConstants.USER_SCHEMA_MISMATCH;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.UUID;
+import java.util.function.Function;
 
 import javax.ws.rs.core.Response;
 import javax.ws.rs.core.UriBuilder;
@@ -47,9 +48,12 @@ import io.vertx.core.json.JsonObject;
 import io.vertx.core.logging.Logger;
 import io.vertx.core.logging.LoggerFactory;
 import io.vertx.ext.web.RoutingContext;
+import org.jetbrains.annotations.NotNull;
 
+import org.folio.rest.annotations.Validate;
 import org.folio.rest.jaxrs.model.FailedUser;
 import org.folio.rest.jaxrs.model.ImportResponse;
+import org.folio.rest.jaxrs.model.RequestPreference;
 import org.folio.rest.jaxrs.model.User;
 import org.folio.rest.jaxrs.model.UserdataimportCollection;
 import org.folio.rest.jaxrs.resource.UserImport;
@@ -59,6 +63,7 @@ import org.folio.rest.tools.client.HttpClientFactory;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 import org.folio.rest.util.CustomFieldsManager;
 import org.folio.rest.util.SingleUserImportResponse;
+import org.folio.rest.util.UserPreferenceService;
 import org.folio.rest.util.UserRecordImportStatus;
 
 public class UserImportAPI implements UserImport {
@@ -69,10 +74,11 @@ public class UserImportAPI implements UserImport {
    * User import entry point.
    */
   @Override
+  @Validate
   public void postUserImport(UserdataimportCollection userCollection, RoutingContext routingContext,
-    Map<String, String> okapiHeaders,
-    Handler<AsyncResult<Response>> asyncResultHandler,
-    Context vertxContext) {
+                             Map<String, String> okapiHeaders, Handler<AsyncResult<Response>> asyncResultHandler,
+                             Context vertxContext) {
+
     if (userCollection.getTotalRecords() == 0) {
       ImportResponse emptyResponse = new ImportResponse()
         .withMessage("No users to import.")
@@ -82,7 +88,7 @@ public class UserImportAPI implements UserImport {
     } else {
       CustomFieldsManager.checkAndUpdateCustomFields(okapiHeaders, userCollection, vertxContext.owner())
         .compose(o -> startUserImport(okapiHeaders, userCollection))
-        .otherwise(throwable -> processErrorResponse(userCollection, throwable.getMessage()))
+        .otherwise(throwable -> processErrorResponse(userCollection.getUsers(), throwable.getMessage()))
         .setHandler(handler -> {
           if (handler.succeeded() && handler.result() != null && handler.result().getError() == null) {
             asyncResultHandler
@@ -106,34 +112,39 @@ public class UserImportAPI implements UserImport {
       .getHttpClient(getOkapiUrl(okapiHeaders), -1, okapiHeaders.get(OKAPI_TENANT_HEADER),
         true, CONN_TO, IDLE_TO, false, 30L);
 
-    getAddressTypes(httpClient, okapiHeaders).setHandler(addressTypeResultHandler -> {
-      if (addressTypeResultHandler.failed()) {
-        LOGGER.error(FAILED_TO_LIST_ADDRESS_TYPES + extractErrorMessage(addressTypeResultHandler));
-        ImportResponse addressTypeListingFailureResponse = processErrorResponse(userCollection, FAILED_TO_LIST_ADDRESS_TYPES + extractErrorMessage(addressTypeResultHandler));
-        future.complete(addressTypeListingFailureResponse);
-      } else {
-        getPatronGroups(httpClient, okapiHeaders).setHandler(patronGroupResultHandler -> {
+    Future<Map<String, String>> addressTypesFuture = getAddressTypes(httpClient, okapiHeaders);
+    Future<Map<String, String>> patronGroupsFuture = getPatronGroups(httpClient, okapiHeaders);
+    Future<Map<String, String>> servicePointsFuture = getServicePoints(httpClient, okapiHeaders);
 
-          if (patronGroupResultHandler.succeeded()) {
-            UserImportData userImportData = new UserImportData(userCollection);
-            userImportData.setAddressTypes(addressTypeResultHandler.result());
-            userImportData.setPatronGroups(patronGroupResultHandler.result());
+    return CompositeFuture.all(addressTypesFuture, patronGroupsFuture, servicePointsFuture)
+      .map(CompositeFuture::<Map<String, String>>list)
+      .map(getUserImportData(userCollection))
+      .compose(importData -> importUsers(importData, httpClient, okapiHeaders, future));
+  }
 
-            if (userImportData.getDeactivateMissingUsers()) {
-              startImportWithDeactivatingUsers(httpClient, okapiHeaders, userCollection, userImportData)
-                .setHandler(future::handle);
-            } else {
-              startImport(httpClient, userCollection, userImportData, okapiHeaders).setHandler(future::handle);
-            }
-          } else {
-            LOGGER.error(FAILED_TO_LIST_PATRON_GROUPS + extractErrorMessage(patronGroupResultHandler));
-            ImportResponse patronGroupListingFailureResponse = processErrorResponse(userCollection, FAILED_TO_LIST_PATRON_GROUPS + extractErrorMessage(patronGroupResultHandler));
-            future.complete(patronGroupListingFailureResponse);
-          }
-        });
-      }
-    });
-    return future.future();
+  @NotNull
+  private Function<List<Map<String, String>>, UserImportData> getUserImportData(UserdataimportCollection userCollection) {
+    return list ->
+      {
+        Map<String, String> addressTypes = list.get(0);
+        Map<String, String> patronGroups = list.get(1);
+        Map<String, String> servicePoints = list.get(2);
+        final UserImportData userImportData = new UserImportData(userCollection);
+        userImportData.setAddressTypes(addressTypes);
+        userImportData.setPatronGroups(patronGroups);
+        userImportData.setServicePoints(servicePoints);
+        return userImportData;
+      };
+  }
+
+  private Future<ImportResponse> importUsers(UserImportData importData, HttpClientInterface httpClient,
+                                             Map<String, String> okapiHeaders, Promise<ImportResponse> future) {
+
+    if (importData.getDeactivateMissingUsers()) {
+      return startImportWithDeactivatingUsers(httpClient, importData, okapiHeaders).setHandler(future);
+    } else {
+      return startImport(httpClient, importData, okapiHeaders).setHandler(future);
+    }
   }
 
   /**
@@ -141,22 +152,23 @@ public class UserImportAPI implements UserImport {
    * should be queried to be able to tell which ones need to be deactivated
    * after the import.
    */
-  private Future<ImportResponse> startImportWithDeactivatingUsers(HttpClientInterface httpClient, Map<String, String> okapiHeaders, UserdataimportCollection userCollection,
-    UserImportData userImportData) {
+  private Future<ImportResponse> startImportWithDeactivatingUsers(HttpClientInterface httpClient,
+                                                                  UserImportData userImportData,
+                                                                  Map<String, String> okapiHeaders) {
 
     Promise<ImportResponse> future = Promise.promise();
-    listAllUsersWithExternalSystemId(httpClient, okapiHeaders, userCollection.getSourceType()).setHandler(handler -> {
+    listAllUsersWithExternalSystemId(httpClient, okapiHeaders, userImportData.getSourceType()).setHandler(handler -> {
 
       if (handler.failed()) {
         LOGGER.error("Failed to list users with externalSystemId (and specific sourceType)");
-        ImportResponse userListingFailureResponse = processErrorResponse(userCollection, FAILED_TO_IMPORT_USERS + extractErrorMessage(handler));
+        ImportResponse userListingFailureResponse = processErrorResponse(userImportData.getUsers(), FAILED_TO_IMPORT_USERS + extractErrorMessage(handler));
         future.complete(userListingFailureResponse);
       } else {
         List<Map> existingUsers = handler.result();
         try {
           final Map<String, User> existingUserMap = extractExistingUsers(existingUsers);
 
-          List<Future> futures = processAllUsersInPartitions(httpClient, userCollection, userImportData, existingUserMap, okapiHeaders);
+          List<Future> futures = processAllUsersInPartitions(httpClient, userImportData, existingUserMap, okapiHeaders);
 
           CompositeFuture.all(futures).setHandler(ar -> {
             if (ar.succeeded()) {
@@ -177,12 +189,12 @@ public class UserImportAPI implements UserImport {
                 });
               }
             } else {
-              ImportResponse userProcessFailureResponse = processErrorResponse(userCollection, FAILED_TO_IMPORT_USERS + extractErrorMessage(ar));
+              ImportResponse userProcessFailureResponse = processErrorResponse(userImportData.getUsers(), FAILED_TO_IMPORT_USERS + extractErrorMessage(ar));
               future.complete(userProcessFailureResponse);
             }
           });
         } catch (UserMappingFailedException exc) {
-          ImportResponse userMappingFailureResponse = processErrorResponse(userCollection, USER_SCHEMA_MISMATCH);
+          ImportResponse userMappingFailureResponse = processErrorResponse(userImportData.getUsers(), USER_SCHEMA_MISMATCH);
           future.complete(userMappingFailureResponse);
         }
       }
@@ -194,14 +206,14 @@ public class UserImportAPI implements UserImport {
    * Create partitions from all users, process them and return the list of
    * Futures of the partition processing.
    */
-  private List<Future> processAllUsersInPartitions(HttpClientInterface httpClient, UserdataimportCollection userCollection, UserImportData userImportData, Map<String, User> existingUserMap, Map<String, String> okapiHeaders) {
+  private List<Future> processAllUsersInPartitions(HttpClientInterface httpClient, UserImportData userImportData,
+                                                   Map<String, User> existingUserMap, Map<String, String> okapiHeaders) {
 
-    List<List<User>> userPartitions = Lists.partition(userCollection.getUsers(), 10);
+    List<List<User>> userPartitions = Lists.partition(userImportData.getUsers(), 10);
     List<Future> futures = new ArrayList<>();
     for (List<User> currentPartition : userPartitions) {
       Future<ImportResponse> userSearchAsyncResult
-        = processUserSearchResult(httpClient, okapiHeaders, existingUserMap,
-          currentPartition, userImportData);
+        = processUserSearchResult(httpClient, okapiHeaders, existingUserMap, currentPartition, userImportData);
       futures.add(userSearchAsyncResult);
     }
     return futures;
@@ -210,10 +222,11 @@ public class UserImportAPI implements UserImport {
   /**
    * Start user import. Partition and process users in batches of 10.
    */
-  private Future<ImportResponse> startImport(HttpClientInterface httpClient, UserdataimportCollection userCollection, UserImportData userImportData, Map<String, String> okapiHeaders) {
+  private Future<ImportResponse> startImport(HttpClientInterface httpClient, UserImportData userImportData,
+                                             Map<String, String> okapiHeaders) {
 
     Promise<ImportResponse> future = Promise.promise();
-    List<List<User>> userPartitions = Lists.partition(userCollection.getUsers(), 10);
+    List<List<User>> userPartitions = Lists.partition(userImportData.getUsers(), 10);
 
     List<Future> futures = new ArrayList<>();
 
@@ -230,7 +243,7 @@ public class UserImportAPI implements UserImport {
         successResponse.setMessage(USERS_WERE_IMPORTED_SUCCESSFULLY);
         future.complete(successResponse);
       } else {
-        ImportResponse userProcessFailureResponse = processErrorResponse(userCollection, FAILED_TO_IMPORT_USERS + extractErrorMessage(ar));
+        ImportResponse userProcessFailureResponse = processErrorResponse(userImportData.getUsers(), FAILED_TO_IMPORT_USERS + extractErrorMessage(ar));
         future.complete(userProcessFailureResponse);
       }
     });
@@ -259,7 +272,7 @@ public class UserImportAPI implements UserImport {
                 UserdataimportCollection userCollection = new UserdataimportCollection();
                 userCollection.setTotalRecords(currentPartition.size());
                 userCollection.setUsers(currentPartition);
-                ImportResponse userSearchFailureResponse = processErrorResponse(userCollection, FAILED_TO_PROCESS_USER_SEARCH_RESULT + extractErrorMessage(response));
+                ImportResponse userSearchFailureResponse = processErrorResponse(userImportData.getUsers(), FAILED_TO_PROCESS_USER_SEARCH_RESULT + extractErrorMessage(response));
                 future.complete(userSearchFailureResponse);
               }
             });
@@ -267,7 +280,7 @@ public class UserImportAPI implements UserImport {
           UserdataimportCollection userCollection = new UserdataimportCollection();
           userCollection.setTotalRecords(currentPartition.size());
           userCollection.setUsers(currentPartition);
-          ImportResponse userMappingFailureResponse = processErrorResponse(userCollection, FAILED_TO_PROCESS_USER_SEARCH_RESULT + USER_SCHEMA_MISMATCH);
+          ImportResponse userMappingFailureResponse = processErrorResponse(userImportData.getUsers(), FAILED_TO_PROCESS_USER_SEARCH_RESULT + USER_SCHEMA_MISMATCH);
           future.complete(userMappingFailureResponse);
         }
 
@@ -276,7 +289,7 @@ public class UserImportAPI implements UserImport {
         UserdataimportCollection userCollection = new UserdataimportCollection();
         userCollection.setTotalRecords(currentPartition.size());
         userCollection.setUsers(currentPartition);
-        ImportResponse userSearchFailureResponse = processErrorResponse(userCollection, FAILED_TO_PROCESS_USER_SEARCH_RESULT + extractErrorMessage(userSearchAsyncResponse));
+        ImportResponse userSearchFailureResponse = processErrorResponse(userImportData.getUsers(), FAILED_TO_PROCESS_USER_SEARCH_RESULT + extractErrorMessage(userSearchAsyncResponse));
         future.complete(userSearchFailureResponse);
       }
     });
@@ -341,11 +354,15 @@ public class UserImportAPI implements UserImport {
           user.setId(existingUsers.get(user.getExternalSystemId()).getId());
         }
         Future<SingleUserImportResponse> userUpdateResponse = updateUser(httpClient, okapiHeaders, user);
+        Future<RequestPreference> userPreference = updateUserPreference(user, userImportData, okapiHeaders);
         futures.add(userUpdateResponse);
+        futures.add(userPreference);
         existingUsers.remove(user.getExternalSystemId());
       } else {
-        Future<SingleUserImportResponse> userCreationResponse = createNewUser(httpClient, okapiHeaders, user);
+        Future<SingleUserImportResponse> userCreationResponse = createNewUser(httpClient, okapiHeaders, user, userImportData);
+        Future<RequestPreference> userPreference = createUserPreference(user, userImportData, okapiHeaders);
         futures.add(userCreationResponse);
+        futures.add(userPreference);
       }
     }
 
@@ -385,7 +402,7 @@ public class UserImportAPI implements UserImport {
     }
     return new ImportResponse()
       .withMessage("")
-      .withTotalRecords(futures.size())
+      .withTotalRecords(created + updated + failed)
       .withCreatedRecords(created)
       .withUpdatedRecords(updated)
       .withFailedRecords(failed)
@@ -428,7 +445,8 @@ public class UserImportAPI implements UserImport {
   /**
    * Create a new user.
    */
-  private Future<SingleUserImportResponse> createNewUser(HttpClientInterface httpClient, Map<String, String> okapiHeaders, User user) {
+  private Future<SingleUserImportResponse> createNewUser(HttpClientInterface httpClient, Map<String, String> okapiHeaders,
+                                                         User user, UserImportData userImportData) {
 
     Promise<SingleUserImportResponse> future = Promise.promise();
     if (user.getId() == null) {
@@ -463,6 +481,37 @@ public class UserImportAPI implements UserImport {
       future.complete(SingleUserImportResponse.failed(user.getExternalSystemId(), user.getUsername(), -1, exc.getMessage()));
     }
     return future.future();
+  }
+
+  private Future<RequestPreference> createUserPreference(User user, UserImportData userImportData,
+                                                         Map<String, String> okapiHeaders) {
+
+    RequestPreference requestPreference = userImportData.getRequestPreference().get(user.getUsername());
+    if (Objects.nonNull(requestPreference)) {
+      requestPreference.setUserId(user.getId());
+      return UserPreferenceService.validate(requestPreference, userImportData)
+        .compose(o -> UserPreferenceService.create(okapiHeaders, requestPreference));
+    } else {
+      return Future.succeededFuture().mapEmpty();
+    }
+  }
+
+  private Future<RequestPreference> updateUserPreference(User user, UserImportData userImportData,
+                                                         Map<String, String> okapiHeaders) {
+    return UserPreferenceService.get(okapiHeaders, user.getId())
+      .compose(result -> {
+        if (Objects.nonNull(result)){
+          RequestPreference requestPreference = userImportData.getRequestPreference().get(user.getUsername());
+          if (Objects.nonNull(requestPreference)) {
+            return UserPreferenceService.validate(requestPreference, userImportData)
+              .compose(o -> UserPreferenceService.update(okapiHeaders, result).mapEmpty());
+          } else {
+            return UserPreferenceService.delete(okapiHeaders, result.getId()).mapEmpty();
+          }
+        } else {
+          return createUserPreference(user, userImportData, okapiHeaders);
+        }
+      });
   }
 
   private Future<JsonObject> addEmptyPermissionSetForUser(HttpClientInterface httpClient, Map<String, String> okapiHeaders, User user) {
@@ -722,9 +771,9 @@ public class UserImportAPI implements UserImport {
    * @param errorMessage the reason of the failure
    * @return the assembled ImportResponse object
    */
-  private ImportResponse processErrorResponse(UserdataimportCollection userCollection, String errorMessage) {
+  private ImportResponse processErrorResponse(List<User> userCollection, String errorMessage) {
     List<FailedUser> failedUsers = new ArrayList<>();
-    for (User user : userCollection.getUsers()) {
+    for (User user : userCollection) {
       FailedUser failedUser = new FailedUser()
         .withExternalSystemId(user.getExternalSystemId())
         .withUsername(user.getUsername())
@@ -734,10 +783,10 @@ public class UserImportAPI implements UserImport {
     return new ImportResponse()
       .withMessage(FAILED_TO_IMPORT_USERS)
       .withError(errorMessage)
-      .withTotalRecords(userCollection.getTotalRecords())
+      .withTotalRecords(userCollection.size())
       .withCreatedRecords(0)
       .withUpdatedRecords(0)
-      .withFailedRecords(userCollection.getTotalRecords())
+      .withFailedRecords(userCollection.size())
       .withFailedUsers(failedUsers);
   }
 

--- a/src/main/java/org/folio/rest/impl/UserImportAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserImportAPI.java
@@ -503,8 +503,10 @@ public class UserImportAPI implements UserImport {
         if (Objects.nonNull(result)){
           RequestPreference requestPreference = userImportData.getRequestPreference().get(user.getUsername());
           if (Objects.nonNull(requestPreference)) {
+            requestPreference.setId(result.getId());
+            requestPreference.setUserId(result.getUserId());
             return UserPreferenceService.validate(requestPreference, userImportData)
-              .compose(o -> UserPreferenceService.update(okapiHeaders, result).mapEmpty());
+              .compose(o -> UserPreferenceService.update(okapiHeaders, requestPreference).mapEmpty());
           } else {
             return UserPreferenceService.delete(okapiHeaders, result.getId()).mapEmpty();
           }

--- a/src/main/java/org/folio/rest/model/UserImportData.java
+++ b/src/main/java/org/folio/rest/model/UserImportData.java
@@ -1,31 +1,38 @@
 package org.folio.rest.model;
 
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
+import org.folio.rest.jaxrs.model.RequestPreference;
+import org.folio.rest.jaxrs.model.User;
 import org.folio.rest.jaxrs.model.UserdataimportCollection;
 
 public class UserImportData {
 
-  private Boolean deactivateMissingUsers;
-
-  private Boolean updateOnlyPresentFields;
-
+  private boolean deactivateMissingUsers;
+  private boolean updateOnlyPresentFields;
   private String sourceType;
-
   private Map<String, String> patronGroups;
-
   private Map<String, String> addressTypes;
+  private Map<String, String> servicePoints;
+  private List<User> users;
+  private Map<String, RequestPreference> requestPreferences;
 
   public UserImportData(UserdataimportCollection userdataCollection) {
-    this.deactivateMissingUsers = userdataCollection.getDeactivateMissingUsers();
-    if (this.deactivateMissingUsers == null) {
-      this.deactivateMissingUsers = Boolean.FALSE;
-    }
-    this.updateOnlyPresentFields = userdataCollection.getUpdateOnlyPresentFields();
-    if (this.updateOnlyPresentFields == null) {
-      this.updateOnlyPresentFields = Boolean.FALSE;
-    }
+    this.deactivateMissingUsers = Boolean.TRUE.equals(userdataCollection.getDeactivateMissingUsers());
+    this.updateOnlyPresentFields = Boolean.TRUE.equals(userdataCollection.getUpdateOnlyPresentFields());
     this.sourceType = userdataCollection.getSourceType();
+    parseUsersAndRequestPreferences(userdataCollection.getUsers());
+  }
+
+  private void parseUsersAndRequestPreferences(List<User> users) {
+    this.requestPreferences = new HashMap<>();
+    for (User user : users) {
+      this.requestPreferences.put(user.getUsername(), user.getRequestPreference());
+      user.setRequestPreference(null);
+    }
+    this.users = users;
   }
 
   public void setPatronGroups(Map<String, String> patronGroups) {
@@ -36,11 +43,11 @@ public class UserImportData {
     this.addressTypes = addressTypes;
   }
 
-  public Boolean getDeactivateMissingUsers() {
+  public boolean getDeactivateMissingUsers() {
     return deactivateMissingUsers;
   }
 
-  public Boolean getUpdateOnlyPresentFields() {
+  public boolean getUpdateOnlyPresentFields() {
     return updateOnlyPresentFields;
   }
 
@@ -56,4 +63,19 @@ public class UserImportData {
     return addressTypes;
   }
 
+  public Map<String, String> getServicePoints() {
+    return servicePoints;
+  }
+
+  public void setServicePoints(Map<String, String> servicePoints) {
+    this.servicePoints = servicePoints;
+  }
+
+  public List<User> getUsers() {
+    return users;
+  }
+
+  public Map<String, RequestPreference> getRequestPreference() {
+    return requestPreferences;
+  }
 }

--- a/src/main/java/org/folio/rest/util/AddressTypeManager.java
+++ b/src/main/java/org/folio/rest/util/AddressTypeManager.java
@@ -1,64 +1,28 @@
 package org.folio.rest.util;
 
-import static org.folio.rest.util.UserImportAPIConstants.*;
+import static org.folio.rest.util.UserImportAPIConstants.ADDRESS_TYPES_ENDPOINT;
+import static org.folio.rest.util.UserImportAPIConstants.FAILED_TO_LIST_ADDRESS_TYPES;
 
-import java.util.HashMap;
 import java.util.Map;
 
-import javax.ws.rs.core.UriBuilder;
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
 
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 
-import io.vertx.core.Future;
-import io.vertx.core.Promise;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
-
 public class AddressTypeManager {
-  private static final Logger LOGGER = LoggerFactory.getLogger(AddressTypeManager.class);
 
-  private AddressTypeManager() {
-  }
+  private static final String ADDRESS_TYPES_ARRAY_KEY = "addressTypes";
+  private static final String ADDRESS_TYPE_OBJECT_KEY = "addressType";
+
+  private AddressTypeManager() {}
 
   public static Future<Map<String, String>> getAddressTypes(HttpClientInterface httpClient, Map<String, String> okapiHeaders) {
-    Promise<Map<String, String>> future = Promise.promise();
-
-    Map<String, String> headers = HttpClientUtil.createHeaders(okapiHeaders, HTTP_HEADER_VALUE_APPLICATION_JSON, null);
-    final String addressTypeQuery = UriBuilder.fromPath("/addresstypes").build().toString();
-
-    try {
-      httpClient.request(addressTypeQuery, headers)
-        .whenComplete((addressTypeResponse, ex) -> {
-          if (ex != null) {
-            LOGGER.error(FAILED_TO_LIST_ADDRESS_TYPES);
-            LOGGER.debug(ex.getMessage());
-            future.fail(ex.getMessage());
-          } else if (!org.folio.rest.tools.client.Response.isSuccess(addressTypeResponse.getCode())) {
-            LOGGER.warn(FAILED_TO_LIST_ADDRESS_TYPES);
-            future.fail("");
-          } else {
-            JsonObject resultObject = addressTypeResponse.getBody();
-            JsonArray addressTypeArray = resultObject.getJsonArray("addressTypes");
-            Map<String, String> addressTypes = extractAddressTypes(addressTypeArray);
-            future.complete(addressTypes);
-          }
-        });
-
-    } catch (Exception exc) {
-      LOGGER.warn("Failed to list address types", exc.getMessage());
-      future.fail(exc);
-    }
-    return future.future();
+    return RequestManager.get(httpClient, okapiHeaders, ADDRESS_TYPES_ENDPOINT, FAILED_TO_LIST_ADDRESS_TYPES)
+      .map(AddressTypeManager::extractAddressTypes);
   }
 
-  private static Map<String, String> extractAddressTypes(JsonArray addressTypes) {
-    Map<String, String> addressTypeMap = new HashMap<>();
-    for (int i = 0; i < addressTypes.size(); i++) {
-      JsonObject addressType = addressTypes.getJsonObject(i);
-      addressTypeMap.put(addressType.getString("addressType"), addressType.getString("id"));
-    }
-    return addressTypeMap;
+  private static Map<String, String> extractAddressTypes(JsonObject result) {
+    return JsonObjectUtil.extractMap(result, ADDRESS_TYPES_ARRAY_KEY, ADDRESS_TYPE_OBJECT_KEY);
   }
 }

--- a/src/main/java/org/folio/rest/util/JsonObjectUtil.java
+++ b/src/main/java/org/folio/rest/util/JsonObjectUtil.java
@@ -1,0 +1,22 @@
+package org.folio.rest.util;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+public class JsonObjectUtil {
+
+  private JsonObjectUtil() {}
+
+  public static Map<String, String> extractMap(JsonObject result, String arrayKey, String objectKey) {
+    Map<String, String> resultMap = new HashMap<>();
+    JsonArray jsonArray = result.getJsonArray(arrayKey);
+    for (int i = 0; i < jsonArray.size(); i++) {
+      JsonObject type = jsonArray.getJsonObject(i);
+      resultMap.put(type.getString(objectKey), type.getString("id"));
+    }
+    return resultMap;
+  }
+}

--- a/src/main/java/org/folio/rest/util/PatronGroupManager.java
+++ b/src/main/java/org/folio/rest/util/PatronGroupManager.java
@@ -1,63 +1,31 @@
 package org.folio.rest.util;
 
-import static org.folio.rest.util.UserImportAPIConstants.*;
+import static org.folio.rest.util.UserImportAPIConstants.FAILED_TO_LIST_PATRON_GROUPS;
+import static org.folio.rest.util.UserImportAPIConstants.PATRON_GROUPS_ENDPOINT;
 
-import java.util.HashMap;
 import java.util.Map;
 
 import javax.ws.rs.core.UriBuilder;
 
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
 
-import io.vertx.core.Future;
-import io.vertx.core.json.JsonArray;
-import io.vertx.core.json.JsonObject;
-import io.vertx.core.logging.Logger;
-import io.vertx.core.logging.LoggerFactory;
-
 public class PatronGroupManager {
-  private static final Logger LOGGER = LoggerFactory.getLogger(PatronGroupManager.class);
 
-  private PatronGroupManager() {
+  private static final String USER_GROUPS_ARRAY_KEY = "usergroups";
+  private static final String USER_GROUP_OBJECT_KEY = "group";
 
-  }
+  private PatronGroupManager() {}
 
   public static Future<Map<String, String>> getPatronGroups(HttpClientInterface httpClient, Map<String, String> okapiHeaders) {
-    Future<Map<String, String>> future = Future.future();
-
-    Map<String, String> headers = HttpClientUtil.createHeaders(okapiHeaders, HTTP_HEADER_VALUE_APPLICATION_JSON, null);
-    final String patronGroupQuery = UriBuilder.fromPath("/groups").queryParam("limit",  "2147483647").build().toString();
-
-    try {
-      httpClient.request(patronGroupQuery, headers)
-        .whenComplete((patronGroupResponse, ex) -> {
-          if (ex != null) {
-            LOGGER.error(FAILED_TO_LIST_PATRON_GROUPS);
-            LOGGER.debug(ex.getMessage());
-            future.fail(ex.getMessage());
-          } else if (!org.folio.rest.tools.client.Response.isSuccess(patronGroupResponse.getCode())) {
-            LOGGER.warn(FAILED_TO_LIST_PATRON_GROUPS);
-            future.fail("");
-          } else {
-            JsonObject resultObject = patronGroupResponse.getBody();
-            JsonArray patronGroupArray = resultObject.getJsonArray("usergroups");
-            Map<String, String> patronGroups = extractPatronGroups(patronGroupArray);
-            future.complete(patronGroups);
-          }
-        });
-    } catch (Exception exc) {
-      LOGGER.warn(FAILED_TO_LIST_PATRON_GROUPS, exc.getMessage());
-      future.fail(exc);
-    }
-    return future;
+    final String query = UriBuilder.fromPath(PATRON_GROUPS_ENDPOINT).queryParam("limit",  "2147483647").build().toString();
+    return RequestManager.get(httpClient, okapiHeaders, query, FAILED_TO_LIST_PATRON_GROUPS)
+      .map(PatronGroupManager::extractPatronGroups);
   }
 
-  private static Map<String, String> extractPatronGroups(JsonArray patronGroups) {
-    Map<String, String> patronGroupMap = new HashMap<>();
-    for (int i = 0; i < patronGroups.size(); i++) {
-      JsonObject patronGroup = patronGroups.getJsonObject(i);
-      patronGroupMap.put(patronGroup.getString("group"), patronGroup.getString("id"));
-    }
-    return patronGroupMap;
+  private static Map<String, String> extractPatronGroups(JsonObject result) {
+    return JsonObjectUtil.extractMap(result, USER_GROUPS_ARRAY_KEY, USER_GROUP_OBJECT_KEY);
   }
 }

--- a/src/main/java/org/folio/rest/util/RequestManager.java
+++ b/src/main/java/org/folio/rest/util/RequestManager.java
@@ -1,0 +1,150 @@
+package org.folio.rest.util;
+
+import static org.folio.rest.util.HttpClientUtil.createHeaders;
+import static org.folio.rest.util.HttpClientUtil.getOkapiUrl;
+import static org.folio.rest.util.UserImportAPIConstants.HTTP_HEADER_VALUE_APPLICATION_JSON;
+import static org.folio.rest.util.UserImportAPIConstants.HTTP_HEADER_VALUE_TEXT_PLAIN;
+import static org.folio.rest.util.UserImportAPIConstants.OKAPI_TENANT_HEADER;
+
+import java.util.Map;
+import java.util.function.BiConsumer;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.http.HttpMethod;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.jetbrains.annotations.NotNull;
+
+import org.folio.rest.tools.client.HttpClientFactory;
+import org.folio.rest.tools.client.Response;
+import org.folio.rest.tools.client.interfaces.HttpClientInterface;
+import org.folio.rest.tools.utils.TenantTool;
+
+public class RequestManager {
+
+  private RequestManager() {}
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(RequestManager.class);
+
+  public static Future<JsonObject> get(HttpClientInterface httpClient, Map<String, String> okapiHeaders, String query,
+                                       String failedMessage) {
+    Promise<JsonObject> future = Promise.promise();
+    Map<String, String> headers = HttpClientUtil.createHeaders(okapiHeaders, HTTP_HEADER_VALUE_APPLICATION_JSON, null);
+    LOGGER.info("Do GET request: {}",  query);
+    try {
+      httpClient.request(query, headers)
+        .whenComplete((response, ex) -> {
+          if (ex != null) {
+            LOGGER.error(failedMessage, ex.getMessage());
+            LOGGER.debug(ex.getMessage());
+            future.fail(failedMessage + ex.getMessage());
+          } else if (!org.folio.rest.tools.client.Response.isSuccess(response.getCode())) {
+            LOGGER.warn(failedMessage + response.getError());
+            future.fail(failedMessage + response.getError());
+          } else {
+            JsonObject resultObject = response.getBody();
+            future.complete(resultObject);
+          }
+        });
+
+    } catch (Exception exc) {
+      LOGGER.warn(failedMessage + exc.getMessage());
+      future.fail(exc);
+    }
+    return future.future();
+  }
+
+  public static <T> Future<T> post(Map<String, String> okapiHeaders, String query,  Class<T> clazz, Object entity, String failedMessage){
+
+    Map<String, String> headers = createHeaders(okapiHeaders, HTTP_HEADER_VALUE_TEXT_PLAIN, HTTP_HEADER_VALUE_APPLICATION_JSON);
+    Promise<T> promise = Promise.promise();
+    try {
+      final HttpClientInterface httpClient = getHttpClient(okapiHeaders);
+      httpClient.request(HttpMethod.POST, JsonObject.mapFrom(entity), query, headers)
+        .thenApply(response -> {
+          try {
+            if (Response.isSuccess(response.getCode())) {
+              return Json.decodeValue(response.getBody().toString(), clazz);
+            } else {
+              LOGGER.error(failedMessage + response.getError().toString(), response.getException());
+              throw new IllegalStateException(failedMessage + response.getError().toString());
+            }
+          } finally {
+            httpClient.closeClient();
+          }
+        })
+        .thenAccept(promise::complete)
+        .exceptionally(e -> {
+          promise.fail(e.getCause());
+          return null;
+        });
+    } catch (Exception e) {
+      LOGGER.error("Cannot perform a request: {} with body: {}. ", query, JsonObject.mapFrom(entity), e.getMessage(), e);
+      promise.fail(e);
+    }
+    return promise.future();
+  }
+
+  public static Future<Void> put(Map<String, String> okapiHeaders, String query, Object entity, String failedMessage) {
+
+    Promise<Void> future = Promise.promise();
+    Map<String, String> headers = createHeaders(okapiHeaders, HTTP_HEADER_VALUE_TEXT_PLAIN, HTTP_HEADER_VALUE_APPLICATION_JSON);
+    try {
+      final HttpClientInterface httpClient = getHttpClient(okapiHeaders);
+      LOGGER.info("Do PUT request: {}",  query);
+      httpClient.request(HttpMethod.PUT, JsonObject.mapFrom(entity), query, headers)
+        .whenComplete(handleResponse(failedMessage, future, httpClient));
+    } catch (Exception exc) {
+      LOGGER.error(failedMessage, exc.getMessage());
+      future.fail(failedMessage + exc.getMessage());
+    }
+    return future.future();
+  }
+
+  public static Future<Void> delete(Map<String, String> okapiHeaders, String query, String id, String failedMessage) {
+    Promise<Void> future = Promise.promise();
+    Map<String, String> headers = createHeaders(okapiHeaders, HTTP_HEADER_VALUE_TEXT_PLAIN, HTTP_HEADER_VALUE_APPLICATION_JSON);
+    try {
+      final HttpClientInterface httpClient = getHttpClient(okapiHeaders);
+      LOGGER.info("Do DELETE request: {}",  query);
+      httpClient.request(HttpMethod.DELETE, id, query, headers)
+        .whenComplete(handleResponse(failedMessage, future, httpClient));
+    } catch (Exception exc) {
+      LOGGER.error(failedMessage, exc.getMessage());
+      future.fail(failedMessage + exc.getMessage());
+    }
+    return future.future();
+  }
+
+  public static HttpClientInterface getHttpClient(Map<String, String> okapiHeaders) {
+    final String okapiURL = getOkapiUrl(okapiHeaders);
+    final String tenantId = TenantTool.calculateTenantId(okapiHeaders.get(OKAPI_TENANT_HEADER));
+
+    return HttpClientFactory.getHttpClient(okapiURL, tenantId);
+  }
+
+  private static boolean isSuccess(org.folio.rest.tools.client.Response response, Throwable ex) {
+    return ex == null && org.folio.rest.tools.client.Response.isSuccess(response.getCode());
+  }
+
+  @NotNull
+  public static BiConsumer<Response, Throwable> handleResponse(String failedMessage, Promise<Void> future, HttpClientInterface httpClient) {
+    return (res, ex) -> {
+      try {
+        if (isSuccess(res, ex)) {
+          future.complete();
+        } else {
+          future.fail(failedMessage + ex.getMessage());
+        }
+      } catch (Exception e) {
+        LOGGER.error(failedMessage, e.getMessage());
+        future.fail(failedMessage + e.getMessage());
+      } finally {
+        httpClient.closeClient();
+      }
+    };
+  }
+}

--- a/src/main/java/org/folio/rest/util/ServicePointsService.java
+++ b/src/main/java/org/folio/rest/util/ServicePointsService.java
@@ -1,0 +1,28 @@
+package org.folio.rest.util;
+
+import static org.folio.rest.util.UserImportAPIConstants.FAILED_TO_LIST_SERVICE_POINTS;
+import static org.folio.rest.util.UserImportAPIConstants.SERVICE_POINTS_ENDPOINT;
+
+import java.util.Map;
+
+import io.vertx.core.Future;
+import io.vertx.core.json.JsonObject;
+
+import org.folio.rest.tools.client.interfaces.HttpClientInterface;
+
+public class ServicePointsService {
+
+  public static final String SERVICE_POINTS_ARRAY_KEY = "servicepoints";
+  public static final String SERVICE_POINT_OBJECT_KEY = "name";
+
+  private ServicePointsService(){}
+
+  public static Future<Map<String, String>> getServicePoints(HttpClientInterface httpClient, Map<String, String> okapiHeaders) {
+    return RequestManager.get(httpClient, okapiHeaders, SERVICE_POINTS_ENDPOINT, FAILED_TO_LIST_SERVICE_POINTS)
+      .map(ServicePointsService::extractServicePoints);
+  }
+
+  private static Map<String, String> extractServicePoints(JsonObject result){
+    return JsonObjectUtil.extractMap(result, SERVICE_POINTS_ARRAY_KEY, SERVICE_POINT_OBJECT_KEY);
+  }
+}

--- a/src/main/java/org/folio/rest/util/UserImportAPIConstants.java
+++ b/src/main/java/org/folio/rest/util/UserImportAPIConstants.java
@@ -14,6 +14,7 @@ public class UserImportAPIConstants {
   public static final String FAILED_TO_LIST_ADDRESS_TYPES = "Failed to list address types.";
   public static final String FAILED_TO_LIST_PATRON_GROUPS = "Failed to list patron groups.";
   public static final String FAILED_TO_LIST_SERVICE_POINTS = "Failed to list service points.";
+  public static final String FAILED_TO_GET_USER_PREFERENCE = "Failed to get user preference.";
   public static final String FAILED_TO_CREATE_USER_PREFERENCE = "Failed to create new user preference.";
   public static final String FAILED_TO_UPDATE_USER_PREFERENCE = "Failed to update user preference.";
   public static final String FAILED_TO_DELETE_USER_PREFERENCE = "Failed to delete user preference.";

--- a/src/main/java/org/folio/rest/util/UserImportAPIConstants.java
+++ b/src/main/java/org/folio/rest/util/UserImportAPIConstants.java
@@ -13,6 +13,11 @@ public class UserImportAPIConstants {
   public static final String FAILED_TO_IMPORT_USERS = "Failed to import users.";
   public static final String FAILED_TO_LIST_ADDRESS_TYPES = "Failed to list address types.";
   public static final String FAILED_TO_LIST_PATRON_GROUPS = "Failed to list patron groups.";
+  public static final String FAILED_TO_LIST_SERVICE_POINTS = "Failed to list service points.";
+  public static final String FAILED_TO_CREATE_USER_PREFERENCE = "Failed to create new user preference.";
+  public static final String FAILED_TO_UPDATE_USER_PREFERENCE = "Failed to update user preference.";
+  public static final String FAILED_TO_DELETE_USER_PREFERENCE = "Failed to delete user preference.";
+  public static final String FAILED_USER_PREFERENCE_VALIDATION = "User Preference validation failed: ";
   public static final String FAILED_TO_GET_USER_MODULE_ID = "Interface 'users' must be provided only by one module";
   public static final String ERROR_MESSAGE = " Error message: ";
   public static final String USERS_WERE_IMPORTED_SUCCESSFULLY = "Users were imported successfully.";
@@ -32,6 +37,12 @@ public class UserImportAPIConstants {
   public static final String GET_CUSTOM_FIELDS_ENDPOINT = "/custom-fields?offset=0&limit=" + Integer.MAX_VALUE;
   public static final String GET_MODULE_ID_ENDPOINT = "/_/proxy/tenants/%s/modules?provide=%s";
   public static final String USERS_INTERFACE_NAME = "users";
+
+  public static final String ADDRESS_TYPES_ENDPOINT = "/addresstypes";
+  public static final String PATRON_GROUPS_ENDPOINT = "/groups";
+  public static final String SERVICE_POINTS_ENDPOINT = "/service-points";
+  public static final String REQUEST_PREFERENCES_ENDPOINT = "/request-preference-storage/request-preference";
+  public static final String REQUEST_PREFERENCES_SEARCH_QUERY_ENDPOINT = REQUEST_PREFERENCES_ENDPOINT + "%s";
 
   public static final int CONN_TO = 5000;
   public static final int IDLE_TO = 10000;

--- a/src/main/java/org/folio/rest/util/UserPreferenceService.java
+++ b/src/main/java/org/folio/rest/util/UserPreferenceService.java
@@ -1,0 +1,78 @@
+package org.folio.rest.util;
+
+import static org.folio.rest.util.UserImportAPIConstants.FAILED_TO_CREATE_USER_PREFERENCE;
+import static org.folio.rest.util.UserImportAPIConstants.FAILED_TO_DELETE_USER_PREFERENCE;
+import static org.folio.rest.util.UserImportAPIConstants.FAILED_TO_UPDATE_USER_PREFERENCE;
+import static org.folio.rest.util.UserImportAPIConstants.FAILED_USER_PREFERENCE_VALIDATION;
+import static org.folio.rest.util.UserImportAPIConstants.REQUEST_PREFERENCES_ENDPOINT;
+import static org.folio.rest.util.UserImportAPIConstants.REQUEST_PREFERENCES_SEARCH_QUERY_ENDPOINT;
+
+import java.util.Map;
+import java.util.function.Function;
+
+import javax.validation.ValidationException;
+
+import io.vertx.core.Future;
+import io.vertx.core.Promise;
+import io.vertx.core.json.JsonObject;
+import io.vertx.core.logging.Logger;
+import io.vertx.core.logging.LoggerFactory;
+import org.jetbrains.annotations.NotNull;
+
+import org.folio.rest.jaxrs.model.RequestPreference;
+import org.folio.rest.model.UserImportData;
+import org.folio.rest.validator.UserRequestManagerValidator;
+
+public class UserPreferenceService {
+
+  public static final String REQUEST_PREFERENCES_ARRAY_KEY = "requestPreferences";
+
+  private UserPreferenceService() {
+  }
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(UserPreferenceService.class);
+
+  public static Future<RequestPreference> get(Map<String, String> okapiHeaders, String userId){
+    String query = String.format(REQUEST_PREFERENCES_SEARCH_QUERY_ENDPOINT , "?query=userId=="+ userId );
+    return RequestManager.get(RequestManager.getHttpClient(okapiHeaders), okapiHeaders, query, "Failed to get user preferences")
+      .map(mapToRequestPreference())
+      .otherwiseEmpty();
+  }
+
+  @NotNull
+  private static Function<JsonObject, RequestPreference> mapToRequestPreference() {
+    return object -> object.getJsonArray(REQUEST_PREFERENCES_ARRAY_KEY)
+      .getJsonObject(0)
+      .mapTo(RequestPreference.class);
+  }
+
+  public static Future<Void> update(Map<String, String> okapiHeaders, RequestPreference entity){
+    String query = String.format(REQUEST_PREFERENCES_SEARCH_QUERY_ENDPOINT , "/" + entity.getId() );
+    return RequestManager.put(okapiHeaders, query, entity, FAILED_TO_UPDATE_USER_PREFERENCE);
+  }
+
+  public static Future<Void> delete(Map<String, String> okapiHeaders, String id){
+    String query = String.format(REQUEST_PREFERENCES_SEARCH_QUERY_ENDPOINT , "/" + id);
+    return RequestManager.delete(okapiHeaders, query, id, FAILED_TO_DELETE_USER_PREFERENCE);
+  }
+
+  public static Future<RequestPreference> create(Map<String, String> okapiHeaders, RequestPreference entity){
+    return RequestManager.post(okapiHeaders, REQUEST_PREFERENCES_ENDPOINT, RequestPreference.class, entity, FAILED_TO_CREATE_USER_PREFERENCE);
+  }
+
+  public static Future<Void> validate(@NotNull RequestPreference entity, @NotNull UserImportData importData) {
+    Promise<Void> promise = Promise.promise();
+    try {
+      UserRequestManagerValidator.validate(entity, importData.getAddressTypes(), importData.getServicePoints());
+      promise.complete();
+    } catch (ValidationException ex){
+      LOGGER.error(FAILED_USER_PREFERENCE_VALIDATION + ex.getMessage());
+      promise.fail(FAILED_USER_PREFERENCE_VALIDATION + ex.getMessage());
+    } catch (Exception e){
+      LOGGER.error("Error occurred" + e.getMessage());
+      promise.fail(e);
+    }
+    return promise.future();
+  }
+
+}

--- a/src/main/java/org/folio/rest/util/UserPreferenceService.java
+++ b/src/main/java/org/folio/rest/util/UserPreferenceService.java
@@ -2,6 +2,7 @@ package org.folio.rest.util;
 
 import static org.folio.rest.util.UserImportAPIConstants.FAILED_TO_CREATE_USER_PREFERENCE;
 import static org.folio.rest.util.UserImportAPIConstants.FAILED_TO_DELETE_USER_PREFERENCE;
+import static org.folio.rest.util.UserImportAPIConstants.FAILED_TO_GET_USER_PREFERENCE;
 import static org.folio.rest.util.UserImportAPIConstants.FAILED_TO_UPDATE_USER_PREFERENCE;
 import static org.folio.rest.util.UserImportAPIConstants.FAILED_USER_PREFERENCE_VALIDATION;
 import static org.folio.rest.util.UserImportAPIConstants.REQUEST_PREFERENCES_ENDPOINT;
@@ -34,7 +35,7 @@ public class UserPreferenceService {
 
   public static Future<RequestPreference> get(Map<String, String> okapiHeaders, String userId){
     String query = String.format(REQUEST_PREFERENCES_SEARCH_QUERY_ENDPOINT , "?query=userId=="+ userId );
-    return RequestManager.get(RequestManager.getHttpClient(okapiHeaders), okapiHeaders, query, "Failed to get user preferences")
+    return RequestManager.get(RequestManager.getHttpClient(okapiHeaders), okapiHeaders, query, FAILED_TO_GET_USER_PREFERENCE)
       .map(mapToRequestPreference())
       .otherwiseEmpty();
   }

--- a/src/main/java/org/folio/rest/util/ValidationUtil.java
+++ b/src/main/java/org/folio/rest/util/ValidationUtil.java
@@ -1,0 +1,36 @@
+package org.folio.rest.util;
+
+import java.util.Collection;
+import java.util.Objects;
+
+import javax.validation.ValidationException;
+
+public class ValidationUtil {
+
+  private ValidationUtil(){}
+
+  private static final String MUST_NOT_BE_NULL_FORMAT = "%s must not be null";
+  private static final String MUST_BE_NULL_FORMAT = "%s must be not specified";
+  private static final String MUST_CONTAINS_IN_LIST_FORMAT = "Provided %s value not in collection";
+
+  public static void checkIsNotNull(String paramName, Object value) {
+    if (Objects.isNull(value)) {
+      throw new ValidationException(
+        String.format(MUST_NOT_BE_NULL_FORMAT, paramName));
+    }
+  }
+
+  public static void checkIsNull(String paramName, Object value) {
+    if (Objects.nonNull(value)) {
+      throw new ValidationException(
+        String.format(MUST_BE_NULL_FORMAT, paramName));
+    }
+  }
+
+  public static void checkValueInStringCollection(String paramName, String value, Collection<String> collection) {
+    if (!collection.contains(value)) {
+      throw new ValidationException(
+        String.format(MUST_CONTAINS_IN_LIST_FORMAT, paramName));
+    }
+  }
+}

--- a/src/main/java/org/folio/rest/util/ValidationUtil.java
+++ b/src/main/java/org/folio/rest/util/ValidationUtil.java
@@ -11,7 +11,7 @@ public class ValidationUtil {
 
   private static final String MUST_NOT_BE_NULL_FORMAT = "%s must not be null";
   private static final String MUST_BE_NULL_FORMAT = "%s must be not specified";
-  private static final String MUST_CONTAINS_IN_LIST_FORMAT = "Provided %s value not in collection";
+  private static final String VALUE_DOES_NOT_EXIST_FORMAT = "Provided %s value does not exist";
 
   public static void checkIsNotNull(String paramName, Object value) {
     if (Objects.isNull(value)) {
@@ -30,7 +30,7 @@ public class ValidationUtil {
   public static void checkValueInStringCollection(String paramName, String value, Collection<String> collection) {
     if (!collection.contains(value)) {
       throw new ValidationException(
-        String.format(MUST_CONTAINS_IN_LIST_FORMAT, paramName));
+        String.format(VALUE_DOES_NOT_EXIST_FORMAT, paramName));
     }
   }
 }

--- a/src/main/java/org/folio/rest/validator/UserRequestManagerValidator.java
+++ b/src/main/java/org/folio/rest/validator/UserRequestManagerValidator.java
@@ -1,0 +1,50 @@
+package org.folio.rest.validator;
+
+import java.util.Map;
+import java.util.Objects;
+
+import org.folio.rest.jaxrs.model.RequestPreference;
+import org.folio.rest.util.ValidationUtil;
+
+public class UserRequestManagerValidator {
+
+  private static final String DELIVERY_PARAMETER = "delivery";
+  private static final String FULFILLMENT_PARAMETER = "fulfillment";
+  private static final String ADDRESS_TYPE_ID = "defaultDeliveryAddressTypeId";
+  public static final String DEFAULT_SERVICE_POINT_PARAMETER = "defaultServicePointId";
+
+  private UserRequestManagerValidator() { }
+
+  public static void validate(RequestPreference requestPreference, Map<String, String> addressTypes, Map<String, String> servicePoints){
+
+    validateDefaultServicePoint(requestPreference, servicePoints);
+    validateDelivery(requestPreference, addressTypes);
+  }
+
+  private static void validateDefaultServicePoint(RequestPreference requestPreference, Map<String, String> servicePoints) {
+    String defaultServicePointId = requestPreference.getDefaultServicePointId();
+
+    if (Objects.nonNull(defaultServicePointId)) {
+      ValidationUtil.checkValueInStringCollection(DEFAULT_SERVICE_POINT_PARAMETER, defaultServicePointId, servicePoints.values());
+    }
+  }
+
+  private static void validateDelivery(RequestPreference requestPreference, Map<String, String> addressTypes) {
+    Boolean hasDelivery = requestPreference.getDelivery();
+    ValidationUtil.checkIsNotNull(DELIVERY_PARAMETER, hasDelivery);
+
+    if (Boolean.TRUE.equals(hasDelivery)){
+      ValidationUtil.checkIsNotNull(FULFILLMENT_PARAMETER, requestPreference.getFulfillment());
+      validateAddressType(requestPreference, addressTypes);
+    } else {
+      ValidationUtil.checkIsNull(FULFILLMENT_PARAMETER, requestPreference.getFulfillment());
+      ValidationUtil.checkIsNull(ADDRESS_TYPE_ID, requestPreference.getDefaultDeliveryAddressTypeId());
+    }
+  }
+
+  private static void validateAddressType(RequestPreference requestPreference, Map<String, String> addressTypes) {
+    String addressTypeId = requestPreference.getDefaultDeliveryAddressTypeId();
+    ValidationUtil.checkIsNotNull(ADDRESS_TYPE_ID, addressTypeId);
+    ValidationUtil.checkValueInStringCollection(ADDRESS_TYPE_ID, addressTypeId, addressTypes.values());
+  }
+}

--- a/src/test/java/org/folio/rest/impl/UserImportAPITest.java
+++ b/src/test/java/org/folio/rest/impl/UserImportAPITest.java
@@ -1322,7 +1322,7 @@ public class UserImportAPITest {
       new RequestPreference()
         .withHoldShelf(RequestPreference.HoldShelf.TRUE)
         .withDelivery(false)
-        .withDefaultServicePointId("00000000-0000-0000-0000-000000000000")
+        .withDefaultServicePointId("00000000-0000-1000-a000-000000000000")
     );
     users.add(user);
 
@@ -1340,7 +1340,7 @@ public class UserImportAPITest {
       .then()
       .body(FAILED_USERS + "[0]." + EXTERNAL_SYSTEM_ID, equalTo(users.get(0).getExternalSystemId()))
       .body(FAILED_USERS + "[0]." + USERNAME, equalTo(users.get(0).getUsername()))
-      .body(FAILED_USERS + "[0]." + USER_ERROR_MESSAGE, containsString(UserImportAPIConstants.FAILED_USER_PREFERENCE_VALIDATION + "Provided defaultServicePointId value not in collection"))
+      .body(FAILED_USERS + "[0]." + USER_ERROR_MESSAGE, containsString(UserImportAPIConstants.FAILED_USER_PREFERENCE_VALIDATION + "Provided defaultServicePointId value does not exist"))
       .statusCode(200);
   }
 
@@ -1355,7 +1355,7 @@ public class UserImportAPITest {
         .withHoldShelf(RequestPreference.HoldShelf.TRUE)
         .withDelivery(true)
         .withDefaultServicePointId("59646a99-4074-4ee5-bfd4-86f3fc7717da")
-        .withDefaultDeliveryAddressTypeId("00000000-0000-0000-0000-000000000000")
+        .withDefaultDeliveryAddressTypeId("11111111-1111-1111-b111-111111111111")
         .withFulfillment(RequestPreference.Fulfillment.DELIVERY)
     );
     users.add(user);
@@ -1374,7 +1374,7 @@ public class UserImportAPITest {
       .then()
       .body(FAILED_USERS + "[0]." + EXTERNAL_SYSTEM_ID, equalTo(users.get(0).getExternalSystemId()))
       .body(FAILED_USERS + "[0]." + USERNAME, equalTo(users.get(0).getUsername()))
-      .body(FAILED_USERS + "[0]." + USER_ERROR_MESSAGE, containsString(UserImportAPIConstants.FAILED_USER_PREFERENCE_VALIDATION + "Provided defaultDeliveryAddressTypeId value not in collection"))
+      .body(FAILED_USERS + "[0]." + USER_ERROR_MESSAGE, containsString(UserImportAPIConstants.FAILED_USER_PREFERENCE_VALIDATION + "Provided defaultDeliveryAddressTypeId value does not exist"))
       .statusCode(200);
   }
 

--- a/src/test/resources/mock_deactivate_in_source_type.json
+++ b/src/test/resources/mock_deactivate_in_source_type.json
@@ -74,7 +74,26 @@
       "receivedPath": "",
       "sendData": {}
     },
-
+    {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
     {
       "url": "/users?query=externalSystemId%3D%5Etest3_%2A&limit=10&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",

--- a/src/test/resources/mock_deactivate_in_source_type_with_deactivation_error.json
+++ b/src/test/resources/mock_deactivate_in_source_type_with_deactivation_error.json
@@ -74,7 +74,26 @@
       "receivedPath": "",
       "sendData": {}
     },
-
+    {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
     {
       "url": "/users?query=externalSystemId%3D%5Etest3_%2A&limit=10&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",

--- a/src/test/resources/mock_deactivate_search_error.json
+++ b/src/test/resources/mock_deactivate_search_error.json
@@ -74,7 +74,26 @@
       "receivedPath": "",
       "sendData": {}
     },
-
+    {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
     {
       "url": "/users?query=externalSystemId%3D%5Etest5_%2A&limit=10&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",

--- a/src/test/resources/mock_import_with_address_add.json
+++ b/src/test/resources/mock_import_with_address_add.json
@@ -74,7 +74,26 @@
       "receivedPath": "",
       "sendData": {}
     },
-
+    {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
     {
       "url": "/users?query=externalSystemId%3D%3D%28user_address%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",

--- a/src/test/resources/mock_import_with_address_rewrite.json
+++ b/src/test/resources/mock_import_with_address_rewrite.json
@@ -74,7 +74,26 @@
       "receivedPath": "",
       "sendData": {}
     },
-
+    {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
     {
       "url": "/users?query=externalSystemId%3D%3D%28user2_address2%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",

--- a/src/test/resources/mock_import_with_address_update.json
+++ b/src/test/resources/mock_import_with_address_update.json
@@ -74,7 +74,26 @@
       "receivedPath": "",
       "sendData": {}
     },
-
+    {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
     {
       "url": "/users?query=externalSystemId%3D%3D%28user_address%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",

--- a/src/test/resources/mock_import_with_existing_address.json
+++ b/src/test/resources/mock_import_with_existing_address.json
@@ -74,7 +74,26 @@
       "receivedPath": "",
       "sendData": {}
     },
-
+    {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
     {
       "url": "/users?query=externalSystemId%3D%3D%28user_address%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",

--- a/src/test/resources/mock_more_user_update.json
+++ b/src/test/resources/mock_more_user_update.json
@@ -74,7 +74,26 @@
       "receivedPath": "",
       "sendData": {}
     },
-
+    {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
     {
       "url": "/users?query=externalSystemId%3C%3E%27%27&limit=10&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",

--- a/src/test/resources/mock_multiple_user_creation.json
+++ b/src/test/resources/mock_multiple_user_creation.json
@@ -74,7 +74,26 @@
       "receivedPath": "",
       "sendData": {}
     },
-
+    {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
     {
       "url": "/users?query=externalSystemId%3D%3D%2811_12+or+21_22+or+31_32+or+41_42+or+51_52+or+61_62+or+71_72+or+81_82+or+91_92+or+101_102%29&limit=20&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",

--- a/src/test/resources/mock_no_need_to_deactivate.json
+++ b/src/test/resources/mock_no_need_to_deactivate.json
@@ -74,7 +74,26 @@
       "receivedPath": "",
       "sendData": {}
     },
-
+    {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
     {
       "url": "/users?query=externalSystemId%3D%5Etest4_%2A&limit=10&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",

--- a/src/test/resources/mock_patron_groups_error.json
+++ b/src/test/resources/mock_patron_groups_error.json
@@ -43,6 +43,26 @@
       "sendData": {}
     },
     {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
+    {
       "url": "/groups?limit=2147483647",
       "method": "get",
       "status": 500,

--- a/src/test/resources/mock_prefixed_user_creation.json
+++ b/src/test/resources/mock_prefixed_user_creation.json
@@ -74,7 +74,26 @@
       "receivedPath": "",
       "sendData": {}
     },
-
+    {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
 
     {
       "url": "/users?query=externalSystemId%3D%3D%28test_test_user%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",

--- a/src/test/resources/mock_prefixed_user_update.json
+++ b/src/test/resources/mock_prefixed_user_update.json
@@ -74,7 +74,26 @@
       "receivedPath": "",
       "sendData": {}
     },
-
+    {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
     {
       "url": "/users?query=externalSystemId%3D%3D%28test2_user2_update2%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",

--- a/src/test/resources/mock_service_points_error.json
+++ b/src/test/resources/mock_service_points_error.json
@@ -77,66 +77,10 @@
     {
       "url": "/service-points",
       "method": "get",
-      "status": 200,
-      "receivedData": {
-        "servicepoints": [{
-          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
-          "name": "Test one"
-        },
-          {
-            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
-            "name": "Test two"
-          },
-          {
-            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
-            "name": "Test three"
-          }
-        ]
-      }
-    },
-    {
-      "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
-      "method": "get",
-      "status": 200,
-      "receivedData": {
-        "users": [],
-        "totalRecords": 0
-      },
+      "status": 500,
+      "receivedData": "Internal server error",
       "receivedPath": "",
       "sendData": {}
-    },
-    {
-      "url": "/users",
-      "method": "post",
-      "status": 201,
-      "receivedData": {
-        "id": "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-        "proxyFor": [],
-        "externalSystemId": "amy_cabble",
-        "barcode": "1234567",
-        "username": "amy_cabble",
-        "active": true,
-        "patronGroup": "undergrad"
-      },
-      "receivedPath": "",
-      "sendData": {
-        "externalSystemId": "amy_cabble",
-        "barcode": "1234567",
-        "username": "amy_cabble",
-        "active": true,
-        "patronGroup": "undergrad"
-      }
-    },
-    {
-      "url": "/perms/users",
-      "method": "post",
-      "status": 201,
-      "receivedData": {},
-      "receivedPath": "",
-      "sendData": {
-        "userId": "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-        "permissions": []
-      }
     }
-   ]
+  ]
 }

--- a/src/test/resources/mock_user_creation.json
+++ b/src/test/resources/mock_user_creation.json
@@ -75,6 +75,26 @@
       "sendData": {}
     },
     {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
+    {
       "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,

--- a/src/test/resources/mock_user_creation_error.json
+++ b/src/test/resources/mock_user_creation_error.json
@@ -74,7 +74,26 @@
       "receivedPath": "",
       "sendData": {}
     },
-
+    {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
     {
       "url": "/users?query=externalSystemId%3D%3D%28error_error%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",

--- a/src/test/resources/mock_user_creation_error_when_deactivating.json
+++ b/src/test/resources/mock_user_creation_error_when_deactivating.json
@@ -74,7 +74,26 @@
       "receivedPath": "",
       "sendData": {}
     },
-
+    {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
     {
       "url": "/users?query=externalSystemId%3C%3E%27%27&limit=10&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",

--- a/src/test/resources/mock_user_creation_with_custom_fields.json
+++ b/src/test/resources/mock_user_creation_with_custom_fields.json
@@ -75,6 +75,26 @@
       "sendData": {}
     },
     {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
+    {
       "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,

--- a/src/test/resources/mock_user_creation_with_custom_fields_with_null_values.json
+++ b/src/test/resources/mock_user_creation_with_custom_fields_with_null_values.json
@@ -75,6 +75,26 @@
       "sendData": {}
     },
     {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
+    {
       "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,

--- a/src/test/resources/mock_user_creation_with_multi_custom_fields.json
+++ b/src/test/resources/mock_user_creation_with_multi_custom_fields.json
@@ -75,6 +75,26 @@
       "sendData": {}
     },
     {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
+    {
       "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,

--- a/src/test/resources/mock_user_creation_with_new_preference.json
+++ b/src/test/resources/mock_user_creation_with_new_preference.json
@@ -113,6 +113,13 @@
         "id": "1ad737b0-d847-11e6-bf26-cec0c932ce01",
         "proxyFor": [],
         "externalSystemId": "amy_cabble",
+        "personal": {
+          "firstName": "Amy",
+          "lastName": "Cabble",
+          "email": "amy_cabble@user.org",
+          "preferredContactTypeId": "email",
+          "addresses": []
+        },
         "barcode": "1234567",
         "username": "amy_cabble",
         "active": true,
@@ -121,6 +128,12 @@
       "receivedPath": "",
       "sendData": {
         "externalSystemId": "amy_cabble",
+        "personal": {
+          "firstName": "Amy",
+          "lastName": "Cabble",
+          "email": "amy_cabble@user.org",
+          "preferredContactTypeId": "email"
+        },
         "barcode": "1234567",
         "username": "amy_cabble",
         "active": true,
@@ -137,6 +150,26 @@
         "userId": "1ad737b0-d847-11e6-bf26-cec0c932ce01",
         "permissions": []
       }
+    },
+    {
+      "url": "/request-preference-storage/request-preference",
+      "method": "post",
+      "status": 200,
+      "receivedData": {
+        "id": "9c007bbd-8c4b-46eb-bd4a-a5b94892f84f",
+        "userId": "2a424823-588a-45ee-9441-a6384b6614b5",
+        "holdShelf": true,
+        "delivery": true,
+        "defaultServicePointId": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+        "defaultDeliveryAddressTypeId": "71628bf4-1962-4dff-a8f2-11108ab532cc",
+        "fulfillment": "Delivery",
+        "metadata": {
+          "createdDate": "2020-07-09T18:15:05.005+0000",
+          "createdByUserId": "2a424823-588a-45ee-9441-a6384b6614b5",
+          "updatedDate": "2020-09-14T18:15:05.005+0000",
+          "updatedByUserId": "2a424823-588a-45ee-9441-a6384b6614b5"
+        }
+      }
     }
-   ]
+  ]
 }

--- a/src/test/resources/mock_user_creation_with_non_existing_patron_group.json
+++ b/src/test/resources/mock_user_creation_with_non_existing_patron_group.json
@@ -75,6 +75,26 @@
       "sendData": {}
     },
     {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
+    {
       "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,

--- a/src/test/resources/mock_user_creation_with_permission_error.json
+++ b/src/test/resources/mock_user_creation_with_permission_error.json
@@ -75,6 +75,26 @@
       "sendData": {}
     },
     {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+        {
+          "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+          "name": "Test two"
+         },
+         {
+          "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+          "name": "Test three"
+         }
+        ]
+      }
+    },
+    {
       "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,

--- a/src/test/resources/mock_user_search_error.json
+++ b/src/test/resources/mock_user_search_error.json
@@ -75,6 +75,26 @@
       "sendData": {}
     },
     {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
+    {
       "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 500,

--- a/src/test/resources/mock_user_update.json
+++ b/src/test/resources/mock_user_update.json
@@ -74,7 +74,26 @@
       "receivedPath": "",
       "sendData": {}
     },
-
+    {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
 
     {
       "url": "/users?query=externalSystemId%3D%3D%28user_update%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",

--- a/src/test/resources/mock_user_update_and_deactivation.json
+++ b/src/test/resources/mock_user_update_and_deactivation.json
@@ -74,7 +74,26 @@
       "receivedPath": "",
       "sendData": {}
     },
-
+    {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
     {
       "url": "/users?query=externalSystemId%3C%3E%27%27&limit=10&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",

--- a/src/test/resources/mock_user_update_error.json
+++ b/src/test/resources/mock_user_update_error.json
@@ -74,7 +74,26 @@
       "receivedPath": "",
       "sendData": {}
     },
-
+    {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
 
     {
       "url": "/users?query=externalSystemId%3D%3D%28user_update%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",

--- a/src/test/resources/mock_user_update_with_new_preference_creation.json
+++ b/src/test/resources/mock_user_update_with_new_preference_creation.json
@@ -95,48 +95,82 @@
       }
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28user_update%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {
-        "users": [],
-        "totalRecords": 0
+        "users": [{
+          "id": "58512926-9a29-483b-b801-d36aced855d3",
+          "externalSystemId": "user_update",
+          "personal": {
+            "firstName": "User",
+            "lastName": "Update",
+            "email": "user_update@user.org",
+            "preferredContactTypeId": "email"
+          },
+          "barcode": "89101112",
+          "username": "user_update",
+          "active": true,
+          "patronGroup": "undergrad"
+        }],
+        "totalRecords": 1
       },
       "receivedPath": "",
       "sendData": {}
     },
     {
-      "url": "/users",
-      "method": "post",
-      "status": 201,
+      "url": "/users/58512926-9a29-483b-b801-d36aced855d3",
+      "method": "put",
+      "status": 204,
       "receivedData": {
-        "id": "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+        "id": "58512926-9a29-483b-b801-d36aced855d3",
         "proxyFor": [],
-        "externalSystemId": "amy_cabble",
-        "barcode": "1234567",
-        "username": "amy_cabble",
+        "externalSystemId": "user_update",
+        "personal": {
+          "firstName": "User",
+          "lastName": "Update",
+          "preferredFirstName": "Preferred User",
+          "email": "user_update@user.org",
+          "preferredContactTypeId": "email",
+          "addresses": []
+        },
+        "barcode": "89101112",
+        "username": "user_update",
         "active": true,
         "patronGroup": "undergrad"
       },
       "receivedPath": "",
       "sendData": {
-        "externalSystemId": "amy_cabble",
-        "barcode": "1234567",
-        "username": "amy_cabble",
+        "externalSystemId": "user_update",
+        "personal": {
+          "firstName": "User",
+          "lastName": "Update",
+          "email": "user_update@user.org",
+          "preferredContactTypeId": "email"
+        },
+        "barcode": "89101112",
+        "username": "user_update",
         "active": true,
         "patronGroup": "undergrad"
       }
     },
     {
-      "url": "/perms/users",
+      "url": "/request-preference-storage/request-preference",
       "method": "post",
-      "status": 201,
-      "receivedData": {},
-      "receivedPath": "",
-      "sendData": {
-        "userId": "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-        "permissions": []
+      "status": 200,
+      "receivedData": {
+        "id": "9c007bbd-8c4b-46eb-bd4a-a5b94892f84f",
+        "userId": "58512926-9a29-483b-b801-d36aced855d3",
+        "holdShelf": true,
+        "delivery": false,
+        "defaultServicePointId": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+        "metadata": {
+          "createdDate": "2020-07-09T18:15:05.005+0000",
+          "createdByUserId": "58512926-9a29-483b-b801-d36aced855d3",
+          "updatedDate": "2020-09-14T18:15:05.005+0000",
+          "updatedByUserId": "58512926-9a29-483b-b801-d36aced855d3"
+        }
       }
     }
-   ]
+  ]
 }

--- a/src/test/resources/mock_user_update_with_no_user_preference.json
+++ b/src/test/resources/mock_user_update_with_no_user_preference.json
@@ -95,48 +95,93 @@
       }
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28user_update%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {
-        "users": [],
-        "totalRecords": 0
+        "users": [{
+          "id": "58512926-9a29-483b-b801-d36aced855d3",
+          "externalSystemId": "user_update",
+          "personal": {
+            "firstName": "User",
+            "lastName": "Update",
+            "email": "user_update@user.org",
+            "preferredContactTypeId": "email"
+          },
+          "barcode": "89101112",
+          "username": "user_update",
+          "active": true,
+          "patronGroup": "undergrad"
+        }],
+        "totalRecords": 1
       },
       "receivedPath": "",
       "sendData": {}
     },
     {
-      "url": "/users",
-      "method": "post",
-      "status": 201,
+      "url": "/users/58512926-9a29-483b-b801-d36aced855d3",
+      "method": "put",
+      "status": 204,
       "receivedData": {
-        "id": "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+        "id": "58512926-9a29-483b-b801-d36aced855d3",
         "proxyFor": [],
-        "externalSystemId": "amy_cabble",
-        "barcode": "1234567",
-        "username": "amy_cabble",
+        "externalSystemId": "user_update",
+        "personal": {
+          "firstName": "User",
+          "lastName": "Update",
+          "preferredFirstName": "Preferred User",
+          "email": "user_update@user.org",
+          "preferredContactTypeId": "email",
+          "addresses": []
+        },
+        "barcode": "89101112",
+        "username": "user_update",
         "active": true,
         "patronGroup": "undergrad"
       },
       "receivedPath": "",
       "sendData": {
-        "externalSystemId": "amy_cabble",
-        "barcode": "1234567",
-        "username": "amy_cabble",
+        "externalSystemId": "user_update",
+        "personal": {
+          "firstName": "User",
+          "lastName": "Update",
+          "email": "user_update@user.org",
+          "preferredContactTypeId": "email"
+        },
+        "barcode": "89101112",
+        "username": "user_update",
         "active": true,
         "patronGroup": "undergrad"
       }
     },
     {
-      "url": "/perms/users",
-      "method": "post",
-      "status": 201,
-      "receivedData": {},
-      "receivedPath": "",
-      "sendData": {
-        "userId": "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-        "permissions": []
+      "url": "/request-preference-storage/request-preference?query=userId==58512926-9a29-483b-b801-d36aced855d3",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "requestPreferences": [
+          {
+            "id": "9c007bbd-8c4b-46eb-bd4a-a5b94892f84f",
+            "userId": "58512926-9a29-483b-b801-d36aced855d3",
+            "holdShelf": true,
+            "delivery": false,
+            "defaultServicePointId": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+            "metadata": {
+              "createdDate": "2020-07-09T18:15:05.005+0000",
+              "createdByUserId": "58512926-9a29-483b-b801-d36aced855d3",
+              "updatedDate": "2020-09-14T18:15:05.005+0000",
+              "updatedByUserId": "58512926-9a29-483b-b801-d36aced855d3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "url": "/request-preference-storage/request-preference/9c007bbd-8c4b-46eb-bd4a-a5b94892f84f",
+      "method": "delete",
+      "status": 204,
+      "receivedData": {
       }
     }
-   ]
+  ]
 }

--- a/src/test/resources/mock_user_update_with_preference_update.json
+++ b/src/test/resources/mock_user_update_with_preference_update.json
@@ -95,48 +95,93 @@
       }
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28user_update%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {
-        "users": [],
-        "totalRecords": 0
+        "users": [{
+          "id": "58512926-9a29-483b-b801-d36aced855d3",
+          "externalSystemId": "user_update",
+          "personal": {
+            "firstName": "User",
+            "lastName": "Update",
+            "email": "user_update@user.org",
+            "preferredContactTypeId": "email"
+          },
+          "barcode": "89101112",
+          "username": "user_update",
+          "active": true,
+          "patronGroup": "undergrad"
+        }],
+        "totalRecords": 1
       },
       "receivedPath": "",
       "sendData": {}
     },
     {
-      "url": "/users",
-      "method": "post",
-      "status": 201,
+      "url": "/users/58512926-9a29-483b-b801-d36aced855d3",
+      "method": "put",
+      "status": 204,
       "receivedData": {
-        "id": "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+        "id": "58512926-9a29-483b-b801-d36aced855d3",
         "proxyFor": [],
-        "externalSystemId": "amy_cabble",
-        "barcode": "1234567",
-        "username": "amy_cabble",
+        "externalSystemId": "user_update",
+        "personal": {
+          "firstName": "User",
+          "lastName": "Update",
+          "preferredFirstName": "Preferred User",
+          "email": "user_update@user.org",
+          "preferredContactTypeId": "email",
+          "addresses": []
+        },
+        "barcode": "89101112",
+        "username": "user_update",
         "active": true,
         "patronGroup": "undergrad"
       },
       "receivedPath": "",
       "sendData": {
-        "externalSystemId": "amy_cabble",
-        "barcode": "1234567",
-        "username": "amy_cabble",
+        "externalSystemId": "user_update",
+        "personal": {
+          "firstName": "User",
+          "lastName": "Update",
+          "email": "user_update@user.org",
+          "preferredContactTypeId": "email"
+        },
+        "barcode": "89101112",
+        "username": "user_update",
         "active": true,
         "patronGroup": "undergrad"
       }
     },
     {
-      "url": "/perms/users",
-      "method": "post",
-      "status": 201,
-      "receivedData": {},
-      "receivedPath": "",
-      "sendData": {
-        "userId": "1ad737b0-d847-11e6-bf26-cec0c932ce01",
-        "permissions": []
+      "url": "/request-preference-storage/request-preference?query=userId==58512926-9a29-483b-b801-d36aced855d3",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "requestPreferences": [
+          {
+            "id": "9c007bbd-8c4b-46eb-bd4a-a5b94892f84f",
+            "userId": "58512926-9a29-483b-b801-d36aced855d3",
+            "holdShelf": true,
+            "delivery": false,
+            "defaultServicePointId": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+            "metadata": {
+              "createdDate": "2020-07-09T18:15:05.005+0000",
+              "createdByUserId": "58512926-9a29-483b-b801-d36aced855d3",
+              "updatedDate": "2020-09-14T18:15:05.005+0000",
+              "updatedByUserId": "58512926-9a29-483b-b801-d36aced855d3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "url": "/request-preference-storage/request-preference/9c007bbd-8c4b-46eb-bd4a-a5b94892f84f",
+      "method": "put",
+      "status": 204,
+      "receivedData": {
       }
     }
-   ]
+  ]
 }

--- a/src/test/resources/mock_user_update_with_wrong_user_schema_in_search_result.json
+++ b/src/test/resources/mock_user_update_with_wrong_user_schema_in_search_result.json
@@ -74,7 +74,26 @@
       "receivedPath": "",
       "sendData": {}
     },
-
+    {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
 
     {
       "url": "/users?query=externalSystemId%3D%3D%28user_update%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",

--- a/src/test/resources/mock_user_update_with_wrong_user_schema_in_search_result_with_deactivation.json
+++ b/src/test/resources/mock_user_update_with_wrong_user_schema_in_search_result_with_deactivation.json
@@ -74,7 +74,26 @@
       "receivedPath": "",
       "sendData": {}
     },
-
+    {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
 
     {
       "url": "/users?query=externalSystemId%3C%3E%27%27&limit=10&offset=0&orderBy=externalSystemId&order=asc",


### PR DESCRIPTION
## Purpose
  implementation story for https://issues.folio.org/browse/MODUIMP-13

## Approach

* extend user import schema to include user request preference
* added user request preference validation
* added implementation to send requests to mod-circulation-storage to create/update/delete request preference
* added tests
* refactored methods 
  ** AddressTypeManager, PatronGroupManager and ServicePointsService to use same method for getting entities
  ** UserImportData - added property to store service points and refactored class to use primitives 
  ** UserImportAPI - refactored method input parameters 