### PR TITLE
MODUIMP-18 Create departments on import

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -25,6 +25,14 @@
           ],
           "modulePermissions": [
             "addresstypes.collection.get",
+            "circulation-storage.request-preferences.collection.get",
+            "circulation-storage.request-preferences.item.delete",
+            "circulation-storage.request-preferences.item.post",
+            "circulation-storage.request-preferences.item.put",
+            "departments.collection.get",
+            "departments.item.post",
+            "departments.item.put",
+            "inventory-storage.service-points.collection.get",
             "perms.users.item.post",
             "user-settings.custom-fields.collection.get",
             "user-settings.custom-fields.collection.put",
@@ -61,7 +69,15 @@
     },
     {
       "id": "users",
-      "version": "14.0 15.0"
+      "version": "15.1"
+    },
+    {
+      "id": "request-preference-storage",
+      "version": "2.0"
+    },
+    {
+      "id": "service-points",
+      "version": "3.2"
     }
   ],
   "launchDescriptor": {
@@ -74,7 +90,8 @@
       }
     },
     "env": [
-      { "name": "JAVA_OPTIONS",
+      {
+        "name": "JAVA_OPTIONS",
         "value": "-XX:MaxRAMPercentage=66.0"
       }
     ]

--- a/pom.xml
+++ b/pom.xml
@@ -27,9 +27,16 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.source>1.8</maven.compiler.source>
     <maven.compiler.target>1.8</maven.compiler.target>
-    <raml-module-builder.version>29.3.0</raml-module-builder.version>
     <ramlfiles_path>${basedir}/ramls</ramlfiles_path>
+    <jsonschema_paths>schemas/**</jsonschema_paths>
     <generate_routing_context>/user-import</generate_routing_context>
+
+    <raml-module-builder.version>29.3.0</raml-module-builder.version>
+    <lombok.version>1.18.12</lombok.version>
+    <vertx.version>3.8.5</vertx.version>
+    <junit.version>4.12</junit.version>
+    <rest-assured.version>3.0.3</rest-assured.version>
+    <wiremock.version>2.19.0</wiremock.version>
   </properties>
 
   <dependencies>
@@ -39,33 +46,38 @@
       <version>${raml-module-builder.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.projectlombok</groupId>
+      <artifactId>lombok</artifactId>
+      <version>${lombok.version}</version>
+    </dependency>
+    <dependency>
       <groupId>junit</groupId>
       <artifactId>junit</artifactId>
-      <version>4.12</version>
+      <version>${junit.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>rest-assured</artifactId>
-      <version>3.0.3</version>
+      <version>${rest-assured.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.rest-assured</groupId>
       <artifactId>json-schema-validator</artifactId>
-      <version>3.0.3</version>
+      <version>${rest-assured.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
-      <version>3.8.5</version>
+      <version>${vertx.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>com.github.tomakehurst</groupId>
       <artifactId>wiremock</artifactId>
-      <version>2.19.0</version>
+      <version>${wiremock.version}</version>
       <exclusions>
         <exclusion>
           <groupId>net.sf.jopt-simple</groupId>
@@ -125,7 +137,6 @@
             </goals>
             <configuration>
               <mainClass>org.folio.rest.tools.GenerateRunner</mainClass>
-              <!-- <executable>java</executable> -->
               <cleanupDaemonThreads>false</cleanupDaemonThreads>
               <systemProperties>
                 <systemProperty>
@@ -136,7 +147,35 @@
                   <key>raml_files</key>
                   <value>${ramlfiles_path}</value>
                 </systemProperty>
+                <systemProperty>
+                  <key>schema_paths</key>
+                  <value>${jsonschema_paths}</value>
+                </systemProperty>
+                <systemProperty>
+                  <key>jsonschema2pojo.config.includeToString</key>
+                  <value>true</value>
+                </systemProperty>
+                <systemProperty>
+                  <key>jsonschema2pojo.config.includeHashcodeAndEquals</key>
+                  <value>true</value>
+                </systemProperty>
               </systemProperties>
+            </configuration>
+          </execution>
+          <execution>
+            <id>git submodule update</id>
+            <phase>initialize</phase>
+            <goals>
+              <goal>exec</goal>
+            </goals>
+            <configuration>
+              <executable>git</executable>
+              <arguments>
+                <argument>submodule</argument>
+                <argument>update</argument>
+                <argument>--init</argument>
+                <argument>--recursive</argument>
+              </arguments>
             </configuration>
           </execution>
         </executions>

--- a/ramls/examples/userdataimportCollection.sample
+++ b/ramls/examples/userdataimportCollection.sample
@@ -26,9 +26,21 @@
         "holdShelf": true,
         "delivery": false,
         "defaultServicePointId": "00000000-0000-1000-a000-000000000000"
-      }
+      },
+      "departments": [
+        "Accounting",
+        "Finance"
+      ]
     }
   ],
+  "included": {
+    "departments": [
+      {
+        "name": "Accounting",
+        "code": "ACC"
+      }
+    ]
+  },
   "totalRecords": 1,
   "deactivateMissingUsers": true,
   "updateOnlyPresentFields": false,

--- a/ramls/import.raml
+++ b/ramls/import.raml
@@ -16,7 +16,9 @@ types:
     body:
       application/json:
         type: userdataimportCollection
-        example: !include examples/userdataimportCollection.sample
+        example:
+          value: !include examples/userdataimportCollection.sample
+          strict: false
     description: Create or update a list of users
     responses:
       200:

--- a/ramls/schemas/department.json
+++ b/ramls/schemas/department.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "http://json-schema.org/draft-04/schema#",
+  "title": "Department",
+  "description": "Department object schema",
+  "javaType": "org.folio.rest.jaxrs.model.Department",
+  "additionalProperties": true,
+  "type": "object",
+  "properties": {
+    "id": {
+      "description": "A UUID identifying this department",
+      "$ref": "../raml-util/schemas/uuid.schema",
+      "example": "f973c3b6-85fc-4d35-bda8-f31b568957bf",
+      "readonly": true,
+      "excludedFromEqualsAndHashCode" : true
+    },
+    "name": {
+      "description": "The unique name of this department",
+      "type": "string",
+      "example": "Accounting"
+    },
+    "code": {
+      "description": "The unique code of this department",
+      "type": "string",
+      "example": "ACC"
+    }
+  },
+  "required": [
+    "name"
+  ]
+}

--- a/ramls/schemas/userdataimport.json
+++ b/ramls/schemas/userdataimport.json
@@ -128,7 +128,7 @@
           }
         },
         "preferredContactTypeId": {
-          "description": "Id of user's preferred contact type",
+          "description": "Name of user's preferred contact type",
           "type": "string"
         }
       },
@@ -172,12 +172,11 @@
       "$ref": "user-import-request-preference.json"
     },
     "departments": {
-      "description": "A UUIDs corresponding to the departments the user belongs to",
+      "description": "Names of departments the user belongs to",
       "type": "array",
       "uniqueItems": true,
       "items": {
-        "type": "string",
-        "$ref": "../raml-util/schemas/uuid.schema"
+        "type": "string"
       }
     }
   },

--- a/ramls/schemas/userdataimportCollection.json
+++ b/ramls/schemas/userdataimportCollection.json
@@ -21,6 +21,23 @@
     },
     "sourceType": {
       "type": "string"
+    },
+    "included": {
+      "description": "Entities that should be imported with users",
+      "javaType": "org.folio.rest.jaxrs.model.IncludedObjects",
+      "additionalProperties": false,
+      "type": "object",
+      "properties": {
+        "departments": {
+          "description": "Departments entities that should be imported with users",
+          "type": "array",
+          "uniqueItems": true,
+          "items": {
+            "type": "object",
+            "$ref": "department.json"
+          }
+        }
+      }
     }
   },
   "required": [

--- a/src/main/java/org/folio/rest/model/UserImportData.java
+++ b/src/main/java/org/folio/rest/model/UserImportData.java
@@ -1,91 +1,56 @@
 package org.folio.rest.model;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
-import org.apache.commons.collections4.map.CaseInsensitiveMap;
+import lombok.Getter;
+
+import org.folio.rest.jaxrs.model.Department;
 import org.folio.rest.jaxrs.model.RequestPreference;
 import org.folio.rest.jaxrs.model.User;
 import org.folio.rest.jaxrs.model.UserdataimportCollection;
 
+@Getter
 public class UserImportData {
 
-  private boolean deactivateMissingUsers;
-  private boolean updateOnlyPresentFields;
-  private String sourceType;
-  private Map<String, String> patronGroups;
-  private Map<String, String> addressTypes;
-  private Map<String, String> servicePoints;
-  private Map<String, String> departments;
-  private List<User> users;
-  private Map<String, RequestPreference> requestPreferences;
+  private final List<User> users;
+  private final Set<Department> departments;
+  private final Map<String, RequestPreference> requestPreferences;
+  private final boolean deactivateMissingUsers;
+  private final boolean updateOnlyPresentFields;
+  private final String sourceType;
 
-  public UserImportData(UserdataimportCollection userdataCollection) {
+  private final UserSystemData systemData;
+
+  private UserImportData(UserdataimportCollection userdataCollection, UserSystemData systemData) {
+    this.users = userdataCollection.getUsers();
     this.deactivateMissingUsers = Boolean.TRUE.equals(userdataCollection.getDeactivateMissingUsers());
     this.updateOnlyPresentFields = Boolean.TRUE.equals(userdataCollection.getUpdateOnlyPresentFields());
     this.sourceType = userdataCollection.getSourceType();
-    parseUsersAndRequestPreferences(userdataCollection.getUsers());
+    this.departments = fetchDepartments(userdataCollection);
+    this.requestPreferences = fetchRequestPreferences(userdataCollection);
+    this.systemData = systemData;
   }
 
-  private void parseUsersAndRequestPreferences(List<User> users) {
-    this.requestPreferences = new HashMap<>();
-    for (User user : users) {
-      this.requestPreferences.put(user.getUsername(), user.getRequestPreference());
+  public static UserImportData from(UserdataimportCollection userdataCollection, UserSystemData systemData) {
+    return new UserImportData(userdataCollection, systemData);
+  }
+
+  private Set<Department> fetchDepartments(UserdataimportCollection userdataCollection) {
+    return userdataCollection.getIncluded() == null
+      ? Collections.emptySet()
+      : userdataCollection.getIncluded().getDepartments();
+  }
+
+  private Map<String, RequestPreference> fetchRequestPreferences(UserdataimportCollection userdataCollection) {
+    final Map<String, RequestPreference> requestPreferenceMap = new HashMap<>();
+    for (User user : userdataCollection.getUsers()) {
+      requestPreferenceMap.put(user.getUsername(), user.getRequestPreference());
       user.setRequestPreference(null);
     }
-    this.users = users;
-  }
-
-  public void setPatronGroups(Map<String, String> patronGroups) {
-    this.patronGroups = new CaseInsensitiveMap<>(patronGroups);
-  }
-
-  public void setAddressTypes(Map<String, String> addressTypes) {
-    this.addressTypes = new CaseInsensitiveMap<>(addressTypes);
-  }
-
-  public boolean getDeactivateMissingUsers() {
-    return deactivateMissingUsers;
-  }
-
-  public boolean getUpdateOnlyPresentFields() {
-    return updateOnlyPresentFields;
-  }
-
-  public String getSourceType() {
-    return sourceType;
-  }
-
-  public Map<String, String> getPatronGroups() {
-    return patronGroups;
-  }
-
-  public Map<String, String> getAddressTypes() {
-    return addressTypes;
-  }
-
-  public Map<String, String> getServicePoints() {
-    return servicePoints;
-  }
-
-  public void setServicePoints(Map<String, String> servicePoints) {
-    this.servicePoints = new CaseInsensitiveMap<>(servicePoints);
-  }
-
-  public List<User> getUsers() {
-    return users;
-  }
-
-  public Map<String, RequestPreference> getRequestPreference() {
-    return requestPreferences;
-  }
-
-  public Map<String, String> getDepartments() {
-    return departments;
-  }
-
-  public void setDepartments(Map<String, String> departments) {
-    this.departments = new CaseInsensitiveMap<>(departments);
+    return requestPreferenceMap;
   }
 }

--- a/src/main/java/org/folio/rest/model/UserSystemData.java
+++ b/src/main/java/org/folio/rest/model/UserSystemData.java
@@ -1,0 +1,21 @@
+package org.folio.rest.model;
+
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import org.folio.rest.jaxrs.model.Department;
+
+@Getter
+@Builder
+public class UserSystemData {
+
+  private Map<String, String> patronGroups;
+  private Map<String, String> addressTypes;
+  private Map<String, String> servicePoints;
+  @Builder.Default
+  private Set<Department> departments = new HashSet<>();
+}

--- a/src/main/java/org/folio/rest/util/AddressTypeManager.java
+++ b/src/main/java/org/folio/rest/util/AddressTypeManager.java
@@ -8,8 +8,6 @@ import java.util.Map;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 
-import org.folio.rest.tools.client.interfaces.HttpClientInterface;
-
 public class AddressTypeManager {
 
   private static final String ADDRESS_TYPES_ARRAY_KEY = "addressTypes";
@@ -17,8 +15,8 @@ public class AddressTypeManager {
 
   private AddressTypeManager() {}
 
-  public static Future<Map<String, String>> getAddressTypes(HttpClientInterface httpClient, Map<String, String> okapiHeaders) {
-    return RequestManager.get(httpClient, okapiHeaders, ADDRESS_TYPES_ENDPOINT, FAILED_TO_LIST_ADDRESS_TYPES)
+  public static Future<Map<String, String>> getAddressTypes(Map<String, String> okapiHeaders) {
+    return RequestManager.get(okapiHeaders, ADDRESS_TYPES_ENDPOINT, FAILED_TO_LIST_ADDRESS_TYPES)
       .map(AddressTypeManager::extractAddressTypes);
   }
 

--- a/src/main/java/org/folio/rest/util/CustomFieldsManager.java
+++ b/src/main/java/org/folio/rest/util/CustomFieldsManager.java
@@ -26,12 +26,11 @@ import io.vertx.core.Future;
 import io.vertx.core.Vertx;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
-
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
 
 import org.folio.rest.jaxrs.model.CustomFields;
 import org.folio.rest.jaxrs.model.User;
-import org.folio.rest.jaxrs.model.UserdataimportCollection;
+import org.folio.rest.model.UserImportData;
 import org.folio.rest.tools.client.HttpClientFactory;
 import org.folio.rest.tools.client.Response;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
@@ -42,10 +41,10 @@ public final class CustomFieldsManager {
   private CustomFieldsManager() {
   }
 
-  public static Future<Void> checkAndUpdateCustomFields(Map<String, String> okapiHeaders,
-                                                        UserdataimportCollection userCollection, Vertx vertx) {
+  public static Future<Void> prepareCustomFields(UserImportData importData, Map<String, String> okapiHeaders,
+                                                 Vertx vertx) {
     Future<Void> future = Future.future();
-    Map<String, Set<String>> customFieldsOptions = getCustomFieldsOptions(userCollection);
+    Map<String, Set<String>> customFieldsOptions = getCustomFieldsOptions(importData);
 
     Map<String, String> headers = new CaseInsensitiveMap<>(okapiHeaders);
     HttpClientInterface httpClient = HttpClientFactory
@@ -71,9 +70,9 @@ public final class CustomFieldsManager {
   }
 
   @SuppressWarnings("unchecked")
-  private static Map<String, Set<String>> getCustomFieldsOptions(UserdataimportCollection userCollection) {
+  private static Map<String, Set<String>> getCustomFieldsOptions(UserImportData importData) {
     Map<String, Set<String>> customFieldsOptions = new HashMap<>();
-    userCollection.getUsers()
+    importData.getUsers()
       .stream()
       .map(User::getCustomFields)
       .filter(Objects::nonNull)

--- a/src/main/java/org/folio/rest/util/DepartmentsManager.java
+++ b/src/main/java/org/folio/rest/util/DepartmentsManager.java
@@ -1,27 +1,143 @@
 package org.folio.rest.util;
 
-import io.vertx.core.Future;
-import io.vertx.core.json.JsonObject;
-import org.folio.rest.tools.client.interfaces.HttpClientInterface;
-
-import java.util.Map;
+import static io.vertx.core.Future.succeededFuture;
 
 import static org.folio.rest.util.UserImportAPIConstants.DEPARTMENTS_ENDPOINT;
 import static org.folio.rest.util.UserImportAPIConstants.FAILED_TO_LIST_DEPARTMENTS;
 
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import io.vertx.core.Future;
+import io.vertx.core.impl.CompositeFutureImpl;
+import io.vertx.core.json.Json;
+import io.vertx.core.json.JsonObject;
+import org.apache.commons.lang3.StringUtils;
+
+import org.folio.rest.jaxrs.model.Department;
+import org.folio.rest.jaxrs.model.User;
+import org.folio.rest.model.UserImportData;
+
 public class DepartmentsManager {
 
   private static final String DEPARTMENTS_ARRAY_KEY = "departments";
-  private static final String DEPARTMENT_NAME_OBJECT_KEY = "name";
+  private static final String DEPARTMENTS_NOT_EXIST_MESSAGE = "Departments do not exist in the system: [%s]";
+  private static final String FAILED_TO_CREATE_DEPARTMENT_MESSAGE = "Failed to create department";
+  private static final String FAILED_TO_UPDATE_DEPARTMENT_MESSAGE = "Failed to update department";
 
   private DepartmentsManager() {}
 
-  public static Future<Map<String, String>> getDepartments(HttpClientInterface httpClient, Map<String, String> okapiHeaders) {
-    return RequestManager.get(httpClient, okapiHeaders, DEPARTMENTS_ENDPOINT, FAILED_TO_LIST_DEPARTMENTS)
+  public static Future<Void> prepareDepartments(UserImportData importData,
+                                                Map<String, String> okapiHeaders) {
+    return getDepartments(okapiHeaders)
+      .compose(systemDepartments -> {
+        Set<Department> importDepartments = importData.getDepartments();
+        if (!importDepartments.isEmpty()) {
+          return updateSystemDepartments(importDepartments, systemDepartments, okapiHeaders);
+        } else {
+          return succeededFuture(systemDepartments);
+        }
+      })
+      .compose(systemDepartments -> checkDepartmentsExistence(importData, systemDepartments));
+  }
+
+  private static Future<Void> checkDepartmentsExistence(UserImportData importData, Set<Department> systemDepartments) {
+    Set<String> usersDepartmentNames = fetchUsersDepartmentNames(importData);
+    Set<String> missedDepartmentNames = findMissedDepartments(systemDepartments, usersDepartmentNames);
+
+    if (!missedDepartmentNames.isEmpty()) {
+      String errorMessage = String.format(DEPARTMENTS_NOT_EXIST_MESSAGE, String.join(", ", missedDepartmentNames));
+      return Future.failedFuture(errorMessage);
+    }
+    importData.getSystemData().getDepartments().addAll(systemDepartments);
+    return succeededFuture();
+  }
+
+  private static Set<String> findMissedDepartments(Set<Department> systemDepartments, Set<String> usersDepartmentNames) {
+    Set<String> missedDepartmentNames = new TreeSet<>();
+    usersDepartmentNames.forEach(departmentName -> {
+      if (!findDepartmentByName(systemDepartments, departmentName).isPresent()) {
+        missedDepartmentNames.add(departmentName);
+      }
+    });
+    return missedDepartmentNames;
+  }
+
+  private static Set<String> fetchUsersDepartmentNames(UserImportData importData) {
+    return importData.getUsers().stream()
+      .map(User::getDepartments)
+      .flatMap(Collection::stream)
+      .collect(Collectors.toSet());
+  }
+
+  private static Future<Set<Department>> updateSystemDepartments(Set<Department> importDepartments,
+                                                                 Set<Department> systemDepartments,
+                                                                 Map<String, String> okapiHeaders) {
+    List<Future<Void>> futures = new ArrayList<>();
+    for (Department importDepartment : importDepartments) {
+      Optional<Department> existedDepartmentByName = findDepartmentByName(systemDepartments, importDepartment.getName());
+      if (!existedDepartmentByName.isPresent()) {
+        Optional<Department> existedDepartmentByCode =
+          findDepartmentByCode(systemDepartments, importDepartment.getCode());
+        if (existedDepartmentByCode.isPresent()) {
+          Department systemDepartment = existedDepartmentByCode.get();
+          futures.add(updateDepartment(systemDepartment, importDepartment, okapiHeaders));
+          systemDepartment.setName(importDepartment.getName());
+        } else {
+          futures.add(createDepartment(importDepartment, okapiHeaders)
+            .onSuccess(systemDepartments::add)
+            .map(department -> null));
+        }
+      }
+    }
+    return CompositeFutureImpl.all(futures.toArray(new Future[0])).map(o -> systemDepartments);
+  }
+
+  private static Future<Set<Department>> getDepartments(Map<String, String> okapiHeaders) {
+    return RequestManager.get(okapiHeaders, DEPARTMENTS_ENDPOINT, FAILED_TO_LIST_DEPARTMENTS)
       .map(DepartmentsManager::extractDepartments);
   }
 
-  private static Map<String, String> extractDepartments(JsonObject result) {
-    return JsonObjectUtil.extractMap(result, DEPARTMENTS_ARRAY_KEY, DEPARTMENT_NAME_OBJECT_KEY);
+  private static Future<Department> createDepartment(Department department, Map<String, String> okapiHeaders) {
+    if (StringUtils.isBlank(department.getCode())) {
+      department.setCode(generateCode(department.getName()));
+    }
+    return RequestManager
+      .post(okapiHeaders, DEPARTMENTS_ENDPOINT, Department.class, department, FAILED_TO_CREATE_DEPARTMENT_MESSAGE);
   }
+
+  private static Future<Void> updateDepartment(Department existed, Department updated, Map<String, String> okapiHeaders) {
+    return RequestManager
+      .put(okapiHeaders, DEPARTMENTS_ENDPOINT + "/" + existed.getId(), updated, FAILED_TO_UPDATE_DEPARTMENT_MESSAGE);
+  }
+
+  private static String generateCode(String name) {
+    return StringUtils.replaceChars(name.toUpperCase(), ' ', '_');
+  }
+
+  public static Optional<Department> findDepartmentByName(Set<Department> departments, String name) {
+    return departments.stream()
+      .filter(department -> department.getName().equals(name))
+      .findFirst();
+  }
+
+  public static Optional<Department> findDepartmentByCode(Set<Department> departments, String code) {
+    return departments.stream()
+      .filter(department -> department.getCode().equals(code))
+      .findFirst();
+  }
+
+  private static Set<Department> extractDepartments(JsonObject result) {
+    return result.getJsonArray(DEPARTMENTS_ARRAY_KEY)
+      .stream()
+      .map(o -> Json.decodeValue(o.toString(), Department.class))
+      .collect(Collectors.toSet());
+  }
+
 }

--- a/src/main/java/org/folio/rest/util/PatronGroupManager.java
+++ b/src/main/java/org/folio/rest/util/PatronGroupManager.java
@@ -10,8 +10,6 @@ import javax.ws.rs.core.UriBuilder;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 
-import org.folio.rest.tools.client.interfaces.HttpClientInterface;
-
 public class PatronGroupManager {
 
   private static final String USER_GROUPS_ARRAY_KEY = "usergroups";
@@ -19,9 +17,9 @@ public class PatronGroupManager {
 
   private PatronGroupManager() {}
 
-  public static Future<Map<String, String>> getPatronGroups(HttpClientInterface httpClient, Map<String, String> okapiHeaders) {
+  public static Future<Map<String, String>> getPatronGroups(Map<String, String> okapiHeaders) {
     final String query = UriBuilder.fromPath(PATRON_GROUPS_ENDPOINT).queryParam("limit",  "2147483647").build().toString();
-    return RequestManager.get(httpClient, okapiHeaders, query, FAILED_TO_LIST_PATRON_GROUPS)
+    return RequestManager.get(okapiHeaders, query, FAILED_TO_LIST_PATRON_GROUPS)
       .map(PatronGroupManager::extractPatronGroups);
   }
 

--- a/src/main/java/org/folio/rest/util/RequestManager.java
+++ b/src/main/java/org/folio/rest/util/RequestManager.java
@@ -29,12 +29,13 @@ public class RequestManager {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(RequestManager.class);
 
-  public static Future<JsonObject> get(HttpClientInterface httpClient, Map<String, String> okapiHeaders, String query,
+  public static Future<JsonObject> get(Map<String, String> okapiHeaders, String query,
                                        String failedMessage) {
     Promise<JsonObject> future = Promise.promise();
     Map<String, String> headers = HttpClientUtil.createHeaders(okapiHeaders, HTTP_HEADER_VALUE_APPLICATION_JSON, null);
     LOGGER.info("Do GET request: {}",  query);
     try {
+      final HttpClientInterface httpClient = getHttpClient(okapiHeaders);
       httpClient.request(query, headers)
         .whenComplete((response, ex) -> {
           if (ex != null) {
@@ -123,7 +124,7 @@ public class RequestManager {
     final String okapiURL = getOkapiUrl(okapiHeaders);
     final String tenantId = TenantTool.calculateTenantId(okapiHeaders.get(OKAPI_TENANT_HEADER));
 
-    return HttpClientFactory.getHttpClient(okapiURL, tenantId);
+    return HttpClientFactory.getHttpClient(okapiURL, tenantId, true);
   }
 
   private static boolean isSuccess(org.folio.rest.tools.client.Response response, Throwable ex) {

--- a/src/main/java/org/folio/rest/util/ServicePointsService.java
+++ b/src/main/java/org/folio/rest/util/ServicePointsService.java
@@ -8,8 +8,6 @@ import java.util.Map;
 import io.vertx.core.Future;
 import io.vertx.core.json.JsonObject;
 
-import org.folio.rest.tools.client.interfaces.HttpClientInterface;
-
 public class ServicePointsService {
 
   public static final String SERVICE_POINTS_ARRAY_KEY = "servicepoints";
@@ -17,8 +15,8 @@ public class ServicePointsService {
 
   private ServicePointsService(){}
 
-  public static Future<Map<String, String>> getServicePoints(HttpClientInterface httpClient, Map<String, String> okapiHeaders) {
-    return RequestManager.get(httpClient, okapiHeaders, SERVICE_POINTS_ENDPOINT, FAILED_TO_LIST_SERVICE_POINTS)
+  public static Future<Map<String, String>> getServicePoints(Map<String, String> okapiHeaders) {
+    return RequestManager.get(okapiHeaders, SERVICE_POINTS_ENDPOINT, FAILED_TO_LIST_SERVICE_POINTS)
       .map(ServicePointsService::extractServicePoints);
   }
 

--- a/src/main/java/org/folio/rest/util/UserPreferenceService.java
+++ b/src/main/java/org/folio/rest/util/UserPreferenceService.java
@@ -36,7 +36,7 @@ public class UserPreferenceService {
 
   public static Future<RequestPreference> get(Map<String, String> okapiHeaders, String userId){
     String query = String.format(REQUEST_PREFERENCES_SEARCH_QUERY_ENDPOINT , "?query=userId=="+ userId );
-    return RequestManager.get(RequestManager.getHttpClient(okapiHeaders), okapiHeaders, query, FAILED_TO_GET_USER_PREFERENCE)
+    return RequestManager.get(okapiHeaders, query, FAILED_TO_GET_USER_PREFERENCE)
       .map(mapToRequestPreference())
       .otherwiseEmpty();
   }

--- a/src/main/java/org/folio/rest/validator/UserRequestManagerValidator.java
+++ b/src/main/java/org/folio/rest/validator/UserRequestManagerValidator.java
@@ -24,8 +24,8 @@ public class UserRequestManagerValidator {
 
   public static void validate(RequestPreference requestPreference, UserImportData importData, User user){
 
-    validateDefaultServicePoint(requestPreference, importData.getServicePoints());
-    validateDelivery(requestPreference, importData.getAddressTypes(), user);
+    validateDefaultServicePoint(requestPreference, importData.getSystemData().getServicePoints());
+    validateDelivery(requestPreference, importData.getSystemData().getAddressTypes(), user);
   }
 
   private static void validateDefaultServicePoint(RequestPreference requestPreference, Map<String, String> servicePoints) {

--- a/src/test/resources/mock_address_types_error.json
+++ b/src/test/resources/mock_address_types_error.json
@@ -7,6 +7,28 @@
       "receivedData": "Internal server error",
       "receivedPath": "",
       "sendData": {}
+    },
+    {
+      "url": "/departments",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "departments": [
+          {
+            "id": "99958431-4b48-49c6-bfae-911fe592addc",
+            "name": "Accounting",
+            "code": "ACC",
+            "usageNumber": 0
+          },
+          {
+            "id": "7b9741bc-e891-4cde-8516-6a209307aed4",
+            "name": "History",
+            "code": "HIS",
+            "usageNumber": 0
+          }
+        ],
+        "totalRecords": 2
+      }
     }
   ]
 }

--- a/src/test/resources/mock_patron_groups_error.json
+++ b/src/test/resources/mock_patron_groups_error.json
@@ -69,6 +69,28 @@
       "receivedData": "Internal server error",
       "receivedPath": "",
       "sendData": {}
+    },
+    {
+      "url": "/departments",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "departments": [
+          {
+            "id": "99958431-4b48-49c6-bfae-911fe592addc",
+            "name": "Accounting",
+            "code": "ACC",
+            "usageNumber": 0
+          },
+          {
+            "id": "7b9741bc-e891-4cde-8516-6a209307aed4",
+            "name": "History",
+            "code": "HIS",
+            "usageNumber": 0
+          }
+        ],
+        "totalRecords": 2
+      }
     }
   ]
 }

--- a/src/test/resources/mock_user_creation_with_custom_fields_failed_get.json
+++ b/src/test/resources/mock_user_creation_with_custom_fields_failed_get.json
@@ -133,6 +133,28 @@
       }
     },
     {
+      "url": "/departments",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "departments": [
+          {
+            "id": "99958431-4b48-49c6-bfae-911fe592addc",
+            "name": "Accounting",
+            "code": "ACC",
+            "usageNumber": 0
+          },
+          {
+            "id": "7b9741bc-e891-4cde-8516-6a209307aed4",
+            "name": "History",
+            "code": "HIS",
+            "usageNumber": 0
+          }
+        ],
+        "totalRecords": 2
+      }
+    },
+    {
       "url": "/perms/users",
       "method": "post",
       "status": 201,
@@ -150,6 +172,26 @@
       "receivedData": "Internal server error.",
       "receivedPath": "",
       "sendData": {}
+    },
+    {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
     },
     {
       "url": "/custom-fields",

--- a/src/test/resources/mock_user_creation_with_new_department.json
+++ b/src/test/resources/mock_user_creation_with_new_department.json
@@ -77,10 +77,22 @@
     {
       "url": "/service-points",
       "method": "get",
-      "status": 500,
-      "receivedData": "Internal server error",
-      "receivedPath": "",
-      "sendData": {}
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
     },
     {
       "url": "/departments",
@@ -102,6 +114,66 @@
           }
         ],
         "totalRecords": 2
+      }
+    },
+    {
+      "url": "/departments",
+      "method": "post",
+      "status": 201,
+      "sendData": {
+        "name": "Financial",
+        "code": "FIN"
+      },
+      "receivedData": {
+        "id": "5343f519-605e-444a-8d01-13c53bd7e9ea",
+        "name": "Financial",
+        "code": "FIN"
+      }
+    },
+    {
+      "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "users": [],
+        "totalRecords": 0
+      },
+      "receivedPath": "",
+      "sendData": {}
+    },
+    {
+      "url": "/users",
+      "method": "post",
+      "status": 201,
+      "receivedData": {
+        "id": "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+        "proxyFor": [],
+        "externalSystemId": "amy_cabble",
+        "barcode": "1234567",
+        "username": "amy_cabble",
+        "active": true,
+        "patronGroup": "undergrad",
+        "departments": ["99958431-4b48-49c6-bfae-911fe592addc"]
+      },
+      "receivedPath": "",
+      "sendData": {
+        "externalSystemId": "amy_cabble",
+        "barcode": "1234567",
+        "username": "amy_cabble",
+        "active": true,
+        "patronGroup": "undergrad",
+        "departments": ["99958431-4b48-49c6-bfae-911fe592addc"]
+      }
+    },
+    {
+      "url": "/perms/users",
+      "method": "post",
+      "status": 201,
+      "receivedData": {},
+      "receivedPath": "",
+      "sendData": {
+        "userId": "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+        "permissions": []
       }
     }
   ]

--- a/src/test/resources/mock_user_creation_with_update_department.json
+++ b/src/test/resources/mock_user_creation_with_update_department.json
@@ -77,10 +77,22 @@
     {
       "url": "/service-points",
       "method": "get",
-      "status": 500,
-      "receivedData": "Internal server error",
-      "receivedPath": "",
-      "sendData": {}
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
     },
     {
       "url": "/departments",
@@ -102,6 +114,61 @@
           }
         ],
         "totalRecords": 2
+      }
+    },
+    {
+      "url": "/departments/99958431-4b48-49c6-bfae-911fe592addc",
+      "method": "put",
+      "status": 204,
+      "sendData": {
+        "name": "Financial Accounting",
+        "code": "ACC"
+      }
+    },
+    {
+      "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "users": [],
+        "totalRecords": 0
+      },
+      "receivedPath": "",
+      "sendData": {}
+    },
+    {
+      "url": "/users",
+      "method": "post",
+      "status": 201,
+      "receivedData": {
+        "id": "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+        "proxyFor": [],
+        "externalSystemId": "amy_cabble",
+        "barcode": "1234567",
+        "username": "amy_cabble",
+        "active": true,
+        "patronGroup": "undergrad",
+        "departments": ["99958431-4b48-49c6-bfae-911fe592addc"]
+      },
+      "receivedPath": "",
+      "sendData": {
+        "externalSystemId": "amy_cabble",
+        "barcode": "1234567",
+        "username": "amy_cabble",
+        "active": true,
+        "patronGroup": "undergrad",
+        "departments": ["99958431-4b48-49c6-bfae-911fe592addc"]
+      }
+    },
+    {
+      "url": "/perms/users",
+      "method": "post",
+      "status": 201,
+      "receivedData": {},
+      "receivedPath": "",
+      "sendData": {
+        "userId": "1ad737b0-d847-11e6-bf26-cec0c932ce01",
+        "permissions": []
       }
     }
   ]


### PR DESCRIPTION
## Purpose

1. Use departments names instead of IDs
2. Create departments on user-import
3. Update departments' names on user-import
4. Return an error if department is not present in the system

## Approach
* update raml definitions
* add required dependencies and permissions in ModuleDescriptor
* update options of model generation in pom.xml
* add implementation
* create tests