### PR TITLE
MODUIMP-42 Fix request preferences deletion while user update

### DIFF
--- a/src/main/java/org/folio/rest/impl/UserImportAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserImportAPI.java
@@ -48,9 +48,9 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
-
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
+
 import org.folio.model.SingleUserImportResponse;
 import org.folio.model.UserImportData;
 import org.folio.model.UserRecordImportStatus;
@@ -580,8 +580,10 @@ public class UserImportAPI implements UserImport {
                 udpService.updateUserPreference(requestPreference, userImportData);
                 return prefService.update(okapiHeaders, requestPreference).mapEmpty();
               });
-          } else {
+          } else if (!userImportData.isUpdateOnlyPresentFields()) {
             return prefService.delete(okapiHeaders, result.getId()).mapEmpty();
+          } else {
+            return Future.succeededFuture(null);
           }
         } else {
           return createUserPreference(user, userImportData, okapiHeaders);

--- a/src/main/java/org/folio/service/UserPreferenceService.java
+++ b/src/main/java/org/folio/service/UserPreferenceService.java
@@ -53,7 +53,7 @@ public class UserPreferenceService {
 
   public Future<Void> delete(Map<String, String> okapiHeaders, String id) {
     String query = String.format(REQUEST_PREFERENCES_SEARCH_QUERY_ENDPOINT, "/" + id);
-    return HttpClientUtil.delete(okapiHeaders, query, id, FAILED_TO_DELETE_USER_PREFERENCE);
+    return HttpClientUtil.delete(okapiHeaders, query, FAILED_TO_DELETE_USER_PREFERENCE);
   }
 
   public Future<RequestPreference> create(Map<String, String> okapiHeaders, RequestPreference entity) {

--- a/src/main/java/org/folio/util/HttpClientUtil.java
+++ b/src/main/java/org/folio/util/HttpClientUtil.java
@@ -16,11 +16,10 @@ import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
 import org.apache.logging.log4j.LogManager;
-
 import org.apache.logging.log4j.Logger;
-import org.folio.okapi.common.XOkapiHeaders;
 import org.jetbrains.annotations.NotNull;
 
+import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.tools.client.HttpClientFactory;
 import org.folio.rest.tools.client.Response;
 import org.folio.rest.tools.client.interfaces.HttpClientInterface;
@@ -109,14 +108,14 @@ public class HttpClientUtil {
     return future.future();
   }
 
-  public static Future<Void> delete(Map<String, String> okapiHeaders, String query, String id, String failedMessage) {
+  public static Future<Void> delete(Map<String, String> okapiHeaders, String query, String failedMessage) {
     Promise<Void> future = Promise.promise();
     try {
       Map<String, String> headers =
           createHeaders(okapiHeaders, HTTP_HEADER_VALUE_TEXT_PLAIN, HTTP_HEADER_VALUE_APPLICATION_JSON);
       final HttpClientInterface httpClient = getHttpClient(okapiHeaders);
       LOGGER.info("Do DELETE request: {}", query);
-      httpClient.request(HttpMethod.DELETE, id, query, headers)
+      httpClient.request(HttpMethod.DELETE, query, headers)
           .whenComplete(handleResponse(failedMessage, future, httpClient));
     } catch (Exception e) {
       LOGGER.error(e.getMessage(), e);

--- a/src/test/java/org/folio/rest/impl/UserImportAPITest.java
+++ b/src/test/java/org/folio/rest/impl/UserImportAPITest.java
@@ -1534,6 +1534,87 @@ public class UserImportAPITest {
       .body(FAILED_RECORDS, equalTo(0))
       .body(FAILED_USERS, hasSize(0))
       .statusCode(200);
+
+  }
+
+  @Test
+  public void testImportUserWithNoPreferencesWithUpdateOnlyPresentFieldAndExistingPreferenceNotDelete() throws IOException {
+    mock.setMockJsonContent("mock_user_update_with_preference_not_delete.json");
+
+    List<User> users = new ArrayList<>();
+    User user = generateUser("89101112", "User", "Update", "58512926-9a29-483b-b801-d36aced855d3");
+    Address address = new Address()
+      .withAddressLine1("Test first line")
+      .withCity("Test city")
+      .withRegion("Test region")
+      .withPostalCode("12345")
+      .withAddressTypeId("Returns")
+      .withPrimaryAddress(Boolean.FALSE);
+    List<Address> addresses = new ArrayList<>();
+    addresses.add(address);
+    user.getPersonal().setAddresses(addresses);
+    users.add(user);
+
+    UserdataimportCollection collection = new UserdataimportCollection()
+      .withUsers(users)
+      .withTotalRecords(1)
+      .withUpdateOnlyPresentFields(true);
+
+    given()
+      .header(TENANT_HEADER)
+      .header(TOKEN_HEADER)
+      .header(new Header(XOkapiHeaders.URL, getWiremockUrl()))
+      .header(JSON_CONTENT_TYPE_HEADER)
+      .body(collection)
+      .post(USER_IMPORT)
+      .then()
+      .body(MESSAGE, equalTo(UserImportAPIConstants.USERS_WERE_IMPORTED_SUCCESSFULLY))
+      .body(TOTAL_RECORDS, equalTo(1))
+      .body(CREATED_RECORDS, equalTo(0))
+      .body(UPDATED_RECORDS, equalTo(1))
+      .body(FAILED_RECORDS, equalTo(0))
+      .body(FAILED_USERS, hasSize(0))
+      .statusCode(200);
+  }
+
+  @Test
+  public void testImportUserWithNoPreferencesWithoutUpdateOnlyPresentFieldAndExistingPreferenceDelete() throws IOException {
+    mock.setMockJsonContent("mock_user_update_with_preference_delete.json");
+
+    List<User> users = new ArrayList<>();
+    User user = generateUser("89101112", "User", "Update", "58512926-9a29-483b-b801-d36aced855d3");
+    Address address = new Address()
+      .withAddressLine1("Test first line")
+      .withCity("Test city")
+      .withRegion("Test region")
+      .withPostalCode("12345")
+      .withAddressTypeId("Returns")
+      .withPrimaryAddress(Boolean.FALSE);
+    List<Address> addresses = new ArrayList<>();
+    addresses.add(address);
+    user.getPersonal().setAddresses(addresses);
+    users.add(user);
+
+    UserdataimportCollection collection = new UserdataimportCollection()
+      .withUsers(users)
+      .withTotalRecords(1)
+      .withUpdateOnlyPresentFields(false);
+
+    given()
+      .header(TENANT_HEADER)
+      .header(TOKEN_HEADER)
+      .header(new Header(XOkapiHeaders.URL, getWiremockUrl()))
+      .header(JSON_CONTENT_TYPE_HEADER)
+      .body(collection)
+      .post(USER_IMPORT)
+      .then()
+      .body(MESSAGE, equalTo(UserImportAPIConstants.USERS_WERE_IMPORTED_SUCCESSFULLY))
+      .body(TOTAL_RECORDS, equalTo(1))
+      .body(CREATED_RECORDS, equalTo(0))
+      .body(UPDATED_RECORDS, equalTo(1))
+      .body(FAILED_RECORDS, equalTo(0))
+      .body(FAILED_USERS, hasSize(0))
+      .statusCode(200);
   }
 
   @Test

--- a/src/test/java/org/folio/util/HttpClientUtilTest.java
+++ b/src/test/java/org/folio/util/HttpClientUtilTest.java
@@ -1,14 +1,15 @@
 package org.folio.util;
 
+import java.util.HashMap;
+import java.util.Map;
+
 import io.vertx.ext.unit.TestContext;
 import io.vertx.ext.unit.junit.VertxUnitRunner;
-import org.folio.okapi.common.XOkapiHeaders;
-import org.folio.rest.jaxrs.model.Department;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
-import java.util.HashMap;
-import java.util.Map;
+import org.folio.okapi.common.XOkapiHeaders;
+import org.folio.rest.jaxrs.model.Department;
 
 @RunWith(VertxUnitRunner.class)
 public class HttpClientUtilTest {
@@ -32,7 +33,7 @@ public class HttpClientUtilTest {
 
   @Test
   public void deleteException(TestContext context) {
-    HttpClientUtil.delete(null, "/a", "1234", "fail")
+    HttpClientUtil.delete(null, "/a", "fail")
         .onComplete(context.asyncAssertFailure(cause ->
             context.assertNull(cause.getMessage(), cause.getMessage())));
   }

--- a/src/test/resources/mock_user_update_with_preference_delete.json
+++ b/src/test/resources/mock_user_update_with_preference_delete.json
@@ -1,0 +1,208 @@
+{
+  "mocks": [
+    {
+      "url": "/addressTypes",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "addressTypes": [
+          {
+            "addressType": "Returns",
+            "desc": "Returns Address",
+            "id": "71628bf4-1962-4dff-a8f2-11108ab532cc"
+          },
+          {
+            "addressType": "Claim",
+            "desc": "Claim Address",
+            "id": "16be835b-c0c7-4454-b1a1-6de1edb82fde"
+          },
+          {
+            "addressType": "Order",
+            "desc": "Order Address",
+            "id": "2f8a8728-00bc-4dda-ae27-b8648186fc27"
+          },
+          {
+            "addressType": "Work",
+            "desc": "Work Address",
+            "id": "9d4ec448-e43a-4528-b257-5e2b4bb4cf0c"
+          },
+          {
+            "addressType": "Home",
+            "desc": "Home Address",
+            "id": "cb9860de-adc2-453c-b449-2328a7a6e651"
+          },
+          {
+            "addressType": "Payment",
+            "desc": "Payment Address",
+            "id": "6c6e8b50-ea63-422b-b882-77ac33021813"
+          }
+        ],
+        "totalRecords": 6
+      },
+      "receivedPath": "",
+      "sendData": {}
+    },
+    {
+      "url": "/groups?limit=2147483647",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "usergroups": [
+          {
+            "group": "undergrad",
+            "desc": "Undergraduate Student",
+            "id": "fd0f9901-2566-4287-bc3c-0cea42eb5963"
+          },
+          {
+            "group": "graduate",
+            "desc": "Graduate Student",
+            "id": "746f7123-193c-48b2-8154-cbc796ab1552"
+          },
+          {
+            "group": "faculty",
+            "desc": "Faculty Member",
+            "id": "c6f61a8d-a86a-4ba3-a112-51925e2f9353"
+          },
+          {
+            "group": "staff",
+            "desc": "Staff Member",
+            "id": "705e1d12-cf84-4d93-9c09-0337958c5cb2"
+          }
+        ],
+        "totalRecords": 4
+      },
+      "receivedPath": "",
+      "sendData": {}
+    },
+    {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
+    {
+      "url": "/departments",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "departments": [],
+        "totalRecords": 0
+      }
+    },
+    {
+      "url": "/custom-fields?offset=0&limit=2147483647",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "customFields": [],
+        "totalRecords": 0
+      },
+      "receivedPath": "",
+      "sendData": {}
+    },
+    {
+      "url": "/users?query=externalSystemId%3D%3D%28user_update%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "users": [
+          {
+            "id": "58512926-9a29-483b-b801-d36aced855d3",
+            "externalSystemId": "user_update",
+            "personal": {
+            "firstName": "User",
+            "lastName": "Update",
+            "email": "user_update@user.org",
+            "preferredContactTypeId": "email"
+          },
+          "barcode": "89101112",
+          "username": "user_update",
+          "active": true,
+          "patronGroup": "undergrad"
+        }],
+        "totalRecords": 1
+      },
+      "receivedPath": "",
+      "sendData": {}
+    },
+    {
+      "url": "/users/58512926-9a29-483b-b801-d36aced855d3",
+      "method": "put",
+      "status": 204,
+      "receivedData": {
+        "id": "58512926-9a29-483b-b801-d36aced855d3",
+        "proxyFor": [],
+        "externalSystemId": "user_update",
+        "personal": {
+          "firstName": "User",
+          "lastName": "Update",
+          "preferredFirstName": "Preferred User",
+          "email": "user_update@user.org",
+          "preferredContactTypeId": "email",
+          "addresses": []
+        },
+        "barcode": "89101112",
+        "username": "user_update",
+        "active": true,
+        "patronGroup": "undergrad"
+      },
+      "receivedPath": "",
+      "sendData": {
+        "externalSystemId": "user_update",
+        "personal": {
+          "firstName": "User",
+          "lastName": "Update",
+          "email": "user_update@user.org",
+          "preferredContactTypeId": "email"
+        },
+        "barcode": "89101112",
+        "username": "user_update",
+        "active": true,
+        "patronGroup": "undergrad"
+      }
+    },
+    {
+      "url": "/request-preference-storage/request-preference?query=userId==58512926-9a29-483b-b801-d36aced855d3",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "requestPreferences": [
+          {
+            "id": "9c007bbd-8c4b-46eb-bd4a-a5b94892f84f",
+            "userId": "58512926-9a29-483b-b801-d36aced855d3",
+            "holdShelf": true,
+            "delivery": false,
+            "defaultServicePointId": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+            "metadata": {
+              "createdDate": "2020-07-09T18:15:05.005+0000",
+              "createdByUserId": "58512926-9a29-483b-b801-d36aced855d3",
+              "updatedDate": "2020-09-14T18:15:05.005+0000",
+              "updatedByUserId": "58512926-9a29-483b-b801-d36aced855d3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "url": "/request-preference-storage/request-preference/9c007bbd-8c4b-46eb-bd4a-a5b94892f84f",
+      "method": "delete",
+      "status": 204,
+      "receivedData": {
+      }
+    }
+  ]
+}

--- a/src/test/resources/mock_user_update_with_preference_not_delete.json
+++ b/src/test/resources/mock_user_update_with_preference_not_delete.json
@@ -1,0 +1,208 @@
+{
+  "mocks": [
+    {
+      "url": "/addressTypes",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "addressTypes": [
+          {
+            "addressType": "Returns",
+            "desc": "Returns Address",
+            "id": "71628bf4-1962-4dff-a8f2-11108ab532cc"
+          },
+          {
+            "addressType": "Claim",
+            "desc": "Claim Address",
+            "id": "16be835b-c0c7-4454-b1a1-6de1edb82fde"
+          },
+          {
+            "addressType": "Order",
+            "desc": "Order Address",
+            "id": "2f8a8728-00bc-4dda-ae27-b8648186fc27"
+          },
+          {
+            "addressType": "Work",
+            "desc": "Work Address",
+            "id": "9d4ec448-e43a-4528-b257-5e2b4bb4cf0c"
+          },
+          {
+            "addressType": "Home",
+            "desc": "Home Address",
+            "id": "cb9860de-adc2-453c-b449-2328a7a6e651"
+          },
+          {
+            "addressType": "Payment",
+            "desc": "Payment Address",
+            "id": "6c6e8b50-ea63-422b-b882-77ac33021813"
+          }
+        ],
+        "totalRecords": 6
+      },
+      "receivedPath": "",
+      "sendData": {}
+    },
+    {
+      "url": "/groups?limit=2147483647",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "usergroups": [
+          {
+            "group": "undergrad",
+            "desc": "Undergraduate Student",
+            "id": "fd0f9901-2566-4287-bc3c-0cea42eb5963"
+          },
+          {
+            "group": "graduate",
+            "desc": "Graduate Student",
+            "id": "746f7123-193c-48b2-8154-cbc796ab1552"
+          },
+          {
+            "group": "faculty",
+            "desc": "Faculty Member",
+            "id": "c6f61a8d-a86a-4ba3-a112-51925e2f9353"
+          },
+          {
+            "group": "staff",
+            "desc": "Staff Member",
+            "id": "705e1d12-cf84-4d93-9c09-0337958c5cb2"
+          }
+        ],
+        "totalRecords": 4
+      },
+      "receivedPath": "",
+      "sendData": {}
+    },
+    {
+      "url": "/service-points",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
+    {
+      "url": "/departments",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "departments": [],
+        "totalRecords": 0
+      }
+    },
+    {
+      "url": "/custom-fields?offset=0&limit=2147483647",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "customFields": [],
+        "totalRecords": 0
+      },
+      "receivedPath": "",
+      "sendData": {}
+    },
+    {
+      "url": "/users?query=externalSystemId%3D%3D%28user_update%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "users": [
+          {
+            "id": "58512926-9a29-483b-b801-d36aced855d3",
+            "externalSystemId": "user_update",
+            "personal": {
+            "firstName": "User",
+            "lastName": "Update",
+            "email": "user_update@user.org",
+            "preferredContactTypeId": "email"
+          },
+          "barcode": "89101112",
+          "username": "user_update",
+          "active": true,
+          "patronGroup": "undergrad"
+        }],
+        "totalRecords": 1
+      },
+      "receivedPath": "",
+      "sendData": {}
+    },
+    {
+      "url": "/users/58512926-9a29-483b-b801-d36aced855d3",
+      "method": "put",
+      "status": 204,
+      "receivedData": {
+        "id": "58512926-9a29-483b-b801-d36aced855d3",
+        "proxyFor": [],
+        "externalSystemId": "user_update",
+        "personal": {
+          "firstName": "User",
+          "lastName": "Update",
+          "preferredFirstName": "Preferred User",
+          "email": "user_update@user.org",
+          "preferredContactTypeId": "email",
+          "addresses": []
+        },
+        "barcode": "89101112",
+        "username": "user_update",
+        "active": true,
+        "patronGroup": "undergrad"
+      },
+      "receivedPath": "",
+      "sendData": {
+        "externalSystemId": "user_update",
+        "personal": {
+          "firstName": "User",
+          "lastName": "Update",
+          "email": "user_update@user.org",
+          "preferredContactTypeId": "email"
+        },
+        "barcode": "89101112",
+        "username": "user_update",
+        "active": true,
+        "patronGroup": "undergrad"
+      }
+    },
+    {
+      "url": "/request-preference-storage/request-preference?query=userId==58512926-9a29-483b-b801-d36aced855d3",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "requestPreferences": [
+          {
+            "id": "9c007bbd-8c4b-46eb-bd4a-a5b94892f84f",
+            "userId": "58512926-9a29-483b-b801-d36aced855d3",
+            "holdShelf": true,
+            "delivery": false,
+            "defaultServicePointId": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+            "metadata": {
+              "createdDate": "2020-07-09T18:15:05.005+0000",
+              "createdByUserId": "58512926-9a29-483b-b801-d36aced855d3",
+              "updatedDate": "2020-09-14T18:15:05.005+0000",
+              "updatedByUserId": "58512926-9a29-483b-b801-d36aced855d3"
+            }
+          }
+        ]
+      }
+    },
+    {
+      "url": "/request-preference-storage/request-preference/9c007bbd-8c4b-46eb-bd4a-a5b94892f84f",
+      "method": "delete",
+      "status": 500,
+      "receivedData": {
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Purpose 
1. Fix an error if we are trying to delete the request preference
2. Not attempt to delete the request preference if `updateOnlyPresentFields` is false

## Approach
1. Fix delete request 
2. Check `updateOnlyPresentFields` before delete preferences