### PR TITLE
MODUIMP-52: RMB 33.0.2, fix HttpClientMock2 not enabled (race condition)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <jsonschema_paths>schemas/**</jsonschema_paths>
     <generate_routing_context>/user-import</generate_routing_context>
 
-    <raml-module-builder-version>33.0.1</raml-module-builder-version>
+    <raml-module-builder-version>33.0.2</raml-module-builder-version>
     <lombok.version>1.18.12</lombok.version>
     <aspectj.version>1.9.6</aspectj.version>
     <log4j-slf4j-impl.version>2.14.0</log4j-slf4j-impl.version>


### PR DESCRIPTION
HttpClientMock2 is not enabled due to race condition,
this fails the build and the release. For details see
https://issues.folio.org/browse/RMB-858

Fix: Upgrade to RMB 33.0.2.