### PR TITLE
MODUIMP-60: Log4j 2.16.0, Vert.x 4.2.2, RMB 33.2.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,12 +37,12 @@
     <jsonschema_paths>schemas/**</jsonschema_paths>
     <generate_routing_context>/user-import</generate_routing_context>
 
-    <raml-module-builder-version>33.1.1</raml-module-builder-version>
+    <raml-module-builder-version>33.1.3</raml-module-builder-version>
     <lombok.version>1.18.12</lombok.version>
     <aspectj.version>1.9.6</aspectj.version>
-    <log4j.version>2.15.0</log4j.version>
+    <log4j.version>2.16.0</log4j.version>
     <jetbrains-annotations.version>20.0.0</jetbrains-annotations.version>
-    <vertx.version>4.1.4</vertx.version>
+    <vertx.version>4.2.2</vertx.version>
     <junit.version>4.13.2</junit.version>
     <rest-assured.version>4.3.0</rest-assured.version>
     <wiremock.version>2.26.3</wiremock.version>

--- a/pom.xml
+++ b/pom.xml
@@ -37,7 +37,7 @@
     <jsonschema_paths>schemas/**</jsonschema_paths>
     <generate_routing_context>/user-import</generate_routing_context>
 
-    <raml-module-builder-version>33.1.3</raml-module-builder-version>
+    <raml-module-builder-version>33.2.2</raml-module-builder-version>
     <lombok.version>1.18.12</lombok.version>
     <aspectj.version>1.9.6</aspectj.version>
     <log4j.version>2.16.0</log4j.version>


### PR DESCRIPTION
Fixing
Log4j https://nvd.nist.gov/vuln/detail/CVE-2021-45046
Log4j https://nvd.nist.gov/vuln/detail/CVE-2021-44228
Netty (Vert.x) https://nvd.nist.gov/vuln/detail/CVE-2021-43797