### PR TITLE
Update to log4j 2.17.1 MODUIMP-66

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -40,24 +40,11 @@
     <raml-module-builder-version>33.2.5</raml-module-builder-version>
     <lombok.version>1.18.12</lombok.version>
     <aspectj.version>1.9.6</aspectj.version>
-    <log4j.version>2.16.0</log4j.version>
     <jetbrains-annotations.version>20.0.0</jetbrains-annotations.version>
     <vertx.version>4.2.4</vertx.version>
     <junit.version>4.13.2</junit.version>
     <rest-assured.version>4.4.0</rest-assured.version>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.apache.logging.log4j</groupId>
-        <artifactId>log4j-bom</artifactId>
-        <version>${log4j.version}</version>
-        <type>pom</type>
-        <scope>import</scope>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -70,10 +57,6 @@
       <artifactId>lombok</artifactId>
       <version>${lombok.version}</version>
       <scope>provided</scope>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-slf4j-impl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.jetbrains</groupId>


### PR DESCRIPTION
Use the one that comes with RMB 33.2.5 (log4j 2.17.1).