### PR TITLE
MODUIMP-67: Unable to Update Custom Fields via User Import

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -11,8 +11,7 @@ buildMvn {
   doDocker = {
     buildJavaDocker {
       publishMaster = 'yes'
-      healthChk = 'yes'
-      healthChkCmd = 'curl -sS --fail -o /dev/null  http://localhost:8081/apidocs/ || exit 1'
+      // healthChk is tested in UserImportIT.java
     }
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,6 @@
     </pluginRepository>
   </pluginRepositories>
 
-
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
@@ -38,6 +37,7 @@
     <generate_routing_context>/user-import</generate_routing_context>
 
     <raml-module-builder-version>33.2.5</raml-module-builder-version>
+    <log4j.version>2.17.2</log4j.version>
     <lombok.version>1.18.12</lombok.version>
     <aspectj.version>1.9.6</aspectj.version>
     <jetbrains-annotations.version>20.0.0</jetbrains-annotations.version>
@@ -45,6 +45,18 @@
     <junit.version>4.13.2</junit.version>
     <rest-assured.version>4.4.0</rest-assured.version>
   </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.testcontainers</groupId>
+        <artifactId>testcontainers-bom</artifactId>
+        <version>1.17.0</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
 
   <dependencies>
     <dependency>
@@ -87,7 +99,30 @@
       <version>${vertx.version}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.logging.log4j</groupId>
+      <artifactId>log4j-slf4j-impl</artifactId>
+      <version>${log4j.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>postgresql</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.testcontainers</groupId>
+      <artifactId>mockserver</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mock-server</groupId>
+      <artifactId>mockserver-client-java</artifactId>
+      <version>5.13.2</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
+
   <distributionManagement>
     <repository>
       <id>folio-nexus</id>
@@ -352,6 +387,19 @@
         </executions>
       </plugin>
 
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <version>3.0.0-M6</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
 
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/src/main/java/org/folio/service/DepartmentsService.java
+++ b/src/main/java/org/folio/service/DepartmentsService.java
@@ -40,7 +40,8 @@ public class DepartmentsService {
         } else {
           return succeededFuture(systemDepartments);
         }
-      });
+      })
+      .recover(e -> HttpClientUtil.errorManagement(e, "Failed to prepare departments"));
   }
 
   public Optional<Department> findDepartmentByName(Set<Department> departments, String name) {

--- a/src/main/java/org/folio/util/OkapiUtil.java
+++ b/src/main/java/org/folio/util/OkapiUtil.java
@@ -24,7 +24,8 @@ public final class OkapiUtil {
     return HttpClientUtil.getRequestOkapi(HttpMethod.GET, okapiHeaders, requestUri)
         .expect(ResponsePredicate.SC_OK)
         .send()
-        .map(res -> extractModuleIds(res.bodyAsJsonArray()));
+        .map(res -> extractModuleIds(res.bodyAsJsonArray()))
+        .recover(e -> HttpClientUtil.errorManagement(e, "Failed to get modules providing interface " + interfaceName));
   }
 
   private static List<String> extractModuleIds(JsonArray jsonArray) {

--- a/src/test/java/org/folio/rest/impl/UserImportIT.java
+++ b/src/test/java/org/folio/rest/impl/UserImportIT.java
@@ -1,0 +1,182 @@
+package org.folio.rest.impl;
+
+import static io.restassured.RestAssured.given;
+import static io.restassured.RestAssured.when;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.mockserver.model.HttpRequest.request;
+import static org.mockserver.model.HttpResponse.response;
+
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Path;
+import org.apache.commons.io.IOUtils;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.mockserver.client.MockServerClient;
+import org.mockserver.model.HttpForward;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.containers.MockServerContainer;
+import org.testcontainers.containers.Network;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.containers.output.Slf4jLogConsumer;
+import org.testcontainers.images.builder.ImageFromDockerfile;
+import org.testcontainers.utility.DockerImageName;
+
+import io.restassured.RestAssured;
+import io.restassured.builder.RequestSpecBuilder;
+import io.restassured.http.ContentType;
+import io.vertx.core.json.JsonArray;
+import io.vertx.core.json.JsonObject;
+
+/**
+ * This integration test runs in the maven integration-test phase and tests that
+ * the shaded fat uber jar works, that the Docker container works, and that
+ * the interaction with the mod-users container works.
+ */
+public class UserImportIT {
+
+  private static final Logger LOGGER = LoggerFactory.getLogger(UserImportIT.class);
+  private static final Network network = Network.newNetwork();
+  private static String modUsersUri;
+
+  @ClassRule
+  public static final GenericContainer<?> module =
+    new GenericContainer<>(new ImageFromDockerfile("mod-user-import").withFileFromPath(".", Path.of(".")))
+      .withNetwork(network)
+      .withNetworkAliases("module")
+      .withExposedPorts(8081);
+
+  @ClassRule
+  public static final GenericContainer<?> modUsers =
+    new GenericContainer<>(DockerImageName.parse("folioorg/mod-users:18.2.0"))
+      .withNetwork(network)
+      .withNetworkAliases("mod-users")
+      .withExposedPorts(8081)
+      .withEnv("DB_HOST", "postgres")
+      .withEnv("DB_PORT", "5432")
+      .withEnv("DB_USERNAME", "username")
+      .withEnv("DB_PASSWORD", "password")
+      .withEnv("DB_DATABASE", "postgres");
+
+  @ClassRule
+  public static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:12-alpine")
+    .withNetwork(network)
+    .withNetworkAliases("postgres")
+    .withExposedPorts(5432)
+    .withUsername("username")
+    .withPassword("password")
+    .withDatabaseName("postgres");
+
+  @ClassRule
+  public static final MockServerContainer okapi =
+    new MockServerContainer(DockerImageName.parse("mockserver/mockserver:mockserver-5.13.2"))
+      .withNetwork(network)
+      .withNetworkAliases("okapi")
+      .withExposedPorts(1080);
+
+  @BeforeClass
+  public static void beforeClass() {
+    module.followOutput(new Slf4jLogConsumer(LOGGER).withSeparateOutputStreams());
+    RestAssured.enableLoggingOfRequestAndResponseIfValidationFails();
+    RestAssured.baseURI = "http://" + module.getHost() + ":" + module.getFirstMappedPort();
+
+    var mockServerClient = new MockServerClient(okapi.getHost(), okapi.getServerPort());
+    mockServerClient.when(request("/_/proxy/tenants/diku/interfaces/custom-fields"))
+      .respond(response().withStatusCode(200).withBody("[{\"id\": \"mod-users\"}]"));
+    mockServerClient.when(request("/perms/users").withMethod("POST"))
+      .respond(response().withStatusCode(201));
+    mockServerClient.when(request("/service-points"))
+      .respond(response().withStatusCode(200).withBody("{\"servicepoints\": []}"));
+    forwardToModUsers(mockServerClient, "/addresstypes.*");
+    forwardToModUsers(mockServerClient, "/custom-fields.*");
+    forwardToModUsers(mockServerClient, "/departments.*");
+    forwardToModUsers(mockServerClient, "/groups.*");
+    forwardToModUsers(mockServerClient, "/proxiesfor.*");
+    forwardToModUsers(mockServerClient, "/users.*");
+
+    RestAssured.requestSpecification = new RequestSpecBuilder()
+      .addHeader("x-okapi-tenant", "diku")
+      .addHeader("x-okapi-url", "http://okapi:1080")
+      .addHeader("x-okapi-url-to", "http://okapi:1080")
+      .addHeader("X-Okapi-User-Id", "2205005b-ca51-4a04-87fd-938eefa8f6de")  // username: rick
+      .setContentType(ContentType.JSON)
+      .build();
+
+    modUsersUri = "http://" + modUsers.getHost() + ":" + modUsers.getFirstMappedPort();
+    enableTenant();
+  }
+
+  private static void forwardToModUsers(MockServerClient mockServerClient, String path) {
+    mockServerClient.when(request(path))
+      .forward(HttpForward.forward().withHost("mod-users").withPort(8081));
+  }
+
+  private static void enableTenant() {
+    String location =
+        given().
+          body(new JsonObject()
+              .put("module_to", "99.99.99")
+              .put("parameters", new JsonArray()
+                  .add(new JsonObject().put("key", "loadReference").put("value", "true"))
+                  .add(new JsonObject().put("key", "loadSample").put("value", "true")))
+              .encode()).
+        when().
+          post(modUsersUri + "/_/tenant").
+        then().
+          statusCode(201).
+        extract().
+          header("Location");
+
+    when().
+      get(modUsersUri + location + "?wait=30000").
+    then().
+      statusCode(200).
+      body("complete", is(true));
+  }
+
+  @Test
+  public void healthTest() {
+    when().
+      get("/admin/health").
+    then().
+      statusCode(200);
+  }
+
+  @Test
+  public void userImportWithCustomFields() {
+    given().
+      body(getResource("/custom-fields.json")).
+    when().
+      post(modUsersUri + "/custom-fields").
+    then().
+      statusCode(201);
+
+    given().
+      body(getResource("/user-import.json")).
+    when().
+      post("/user-import").
+    then().
+      statusCode(200);
+
+    when().
+      get(modUsersUri + "/users?query=externalSystemId==10192").
+    then().
+      statusCode(200).
+      body("users[0].username", is("chani")).
+      body("users[0].customFields.classYear", startsWith("opt_"));
+  }
+
+  private String getResource(String resource) {
+    try {
+      return IOUtils.resourceToString(resource, StandardCharsets.UTF_8);
+    } catch (IOException e) {
+      throw new UncheckedIOException(e);
+    }
+  }
+}
+

--- a/src/test/resources/custom-fields.json
+++ b/src/test/resources/custom-fields.json
@@ -1,0 +1,38 @@
+{
+    "name" : "Class Year",
+    "refId" : "classYear",
+    "type" : "SINGLE_SELECT_DROPDOWN",
+    "entityType" : "user",
+    "visible" : true,
+    "required" : false,
+    "isRepeatable" : false,
+    "order" : 1,
+    "helpText" : "",
+    "selectField" : {
+        "multiSelect" : false,
+        "options" : {
+            "values" : [
+                {
+                    "id" : "opt_0",
+                    "value" : "Employee",
+                    "default" : false
+                },
+                {
+                    "id" : "opt_1",
+                    "value" : "Exchange Student",
+                    "default" : false
+                },
+                {
+                    "id" : "opt_2",
+                    "value" : "Other",
+                    "default" : false
+                },
+                {
+                    "id" : "opt_3",
+                    "value" : "Part Time",
+                    "default" : false
+                }
+            ]
+        }
+    }
+}

--- a/src/test/resources/user-import.json
+++ b/src/test/resources/user-import.json
@@ -1,0 +1,71 @@
+{
+    "users": [
+        {
+            "username": "usul",
+            "externalSystemId": "10191",
+            "patronGroup": "undergrad",
+            "active": true,
+            "personal": {
+                "firstName": "Paul",
+                "lastName": "Atreides",
+                "middleName": "Mua'Dib",
+                "preferredFirstName": "Usul"
+            },
+            "customFields": {
+                "classYear": "2023"
+            }
+        },
+        {
+            "username": "chani",
+            "externalSystemId": "10192",
+            "patronGroup": "graduate",
+            "active": true,
+            "personal": {
+                "firstName": "Chani",
+                "lastName": "Kynes",
+                "preferredFirstName": "Sihaya"
+            },
+            "customFields": {
+                "classYear": "2024"
+            }
+        }
+    ],
+    "included": {
+        "customFields": [
+            {
+                "refId": "classYear",
+                "selectField": {
+                    "options": {
+                        "values": [
+                            {
+                                "value": "2023"
+                            },
+                            {
+                                "value": "2024"
+                            },
+                            {
+                                "value": "2025"
+                            },
+                            {
+                                "value": "Employee"
+                            },
+                            {
+                                "value": "Exchange Student"
+                            },
+                            {
+                                "value": "Other"
+                            },
+                            {
+                                "value": "Part Time"
+                            }
+                        ]
+                    }
+                }
+            }
+        ]
+    },
+    "totalRecords": 2,
+    "deactivateMissingUsers": false,
+    "updateOnlyPresentFields": true
+}
+


### PR DESCRIPTION
In CustomFieldsService.java replace `send()` by `sendJson(customField)`
to fix this issue.

Add missing error logging in UserImportAPI.java, CustomFieldsService.java,
DepartmentsService.java, OkapiUtil.java.

Replace Jenkins healthChk by maven integration tests in UserImportAPI.java
that run mod-user-import and mod-users containers.