### PR TITLE
MODUIMP-69: Update RMB, Vertx, Jackson-Databind (CVE-2020-36518)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,12 +36,12 @@
     <jsonschema_paths>schemas/**</jsonschema_paths>
     <generate_routing_context>/user-import</generate_routing_context>
 
-    <raml-module-builder-version>33.2.5</raml-module-builder-version>
+    <raml-module-builder-version>33.2.9</raml-module-builder-version>
     <log4j.version>2.17.2</log4j.version>
     <lombok.version>1.18.12</lombok.version>
     <aspectj.version>1.9.6</aspectj.version>
     <jetbrains-annotations.version>20.0.0</jetbrains-annotations.version>
-    <vertx.version>4.2.4</vertx.version>
+    <vertx.version>4.2.7</vertx.version>
     <junit.version>4.13.2</junit.version>
     <rest-assured.version>4.4.0</rest-assured.version>
   </properties>


### PR DESCRIPTION
Update RMB from 33.2.5 to 33.2.9 and Vert.x from 4.2.4 to 4.2.7.

This indirectly updates jackson-databind from 2.13.1 to 2.13.2.1 fixing StackOverflow exception and denial of service via a large depth of nested objects: https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2020-36518