### PR TITLE
MODUIMP-88: Check "error" in GET /_/tenant/<tenantid> in UserImportIT

### DIFF
--- a/src/test/java/org/folio/rest/impl/UserImportIT.java
+++ b/src/test/java/org/folio/rest/impl/UserImportIT.java
@@ -138,8 +138,9 @@ public class UserImportIT {
     when().
       get(modUsersUri + location + "?wait=30000").
     then().
-      statusCode(200).
-      body("complete", is(true));
+      statusCode(200).  // getting job record succeeds
+      body("complete", is(true)).  // job is complete
+      body("error", is(nullValue()));  // job has succeeded without error
   }
 
   @Test

--- a/src/test/java/org/folio/rest/impl/UserImportIT.java
+++ b/src/test/java/org/folio/rest/impl/UserImportIT.java
@@ -3,6 +3,7 @@ package org.folio.rest.impl;
 import static io.restassured.RestAssured.given;
 import static io.restassured.RestAssured.when;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.Matchers.startsWith;
 import static org.mockserver.model.HttpRequest.request;
 import static org.mockserver.model.HttpResponse.response;


### PR DESCRIPTION
https://s3.amazonaws.com/foliodocs/api/raml/r/tenant.html#tenant__operation_id__get

Error is indicated in the "error" property only, not in the HTTP status code!