### PR TITLE
MODUIMP-91: Mask externalSystemId

### DIFF
--- a/src/test/java/org/folio/rest/impl/UserImportAPITest.java
+++ b/src/test/java/org/folio/rest/impl/UserImportAPITest.java
@@ -300,23 +300,20 @@ public class UserImportAPITest {
       .statusCode(422);
   }
 
-  /*
-   * This test does not reflect real-time environment currently.
-   */
-  //  @Test
-  public void testImportWithUserWithEmptyExternalSystemId() throws IOException {
+  @Test
+  public void testImportWithUserWithMaskedExternalSystemId() throws IOException {
 
-    mock.setMockJsonContent("mock_user_creation_with_empty_externalsystemid.json");
+    mock.setMockJsonContent("mock_user_creation_with_masked_externalsystemid.json");
 
     List<User> users = new ArrayList<>();
     User testUser = generateUser("1234567", "Amy", "Cabble", null);
-    testUser.setExternalSystemId("");
+    testUser.setExternalSystemId("amy/cab*ble");
     users.add(testUser);
     users.add(testUser);
 
     UserdataimportCollection collection = new UserdataimportCollection()
       .withUsers(users)
-      .withTotalRecords(1);
+      .withTotalRecords(users.size());
 
     given()
       .header(TENANT_HEADER)
@@ -328,14 +325,9 @@ public class UserImportAPITest {
       .then()
       .body(MESSAGE, equalTo(UserImportAPIConstants.USERS_WERE_IMPORTED_SUCCESSFULLY))
       .body(TOTAL_RECORDS, equalTo(2))
-      .body(CREATED_RECORDS, equalTo(1))
+      .body(CREATED_RECORDS, equalTo(2))
       .body(UPDATED_RECORDS, equalTo(0))
-      .body(FAILED_RECORDS, equalTo(1))
-      .body(FAILED_USERS, hasSize(1))
-      .body(FAILED_USERS + "[0]." + EXTERNAL_SYSTEM_ID, equalTo(testUser.getExternalSystemId()))
-      .body(FAILED_USERS + "[0]." + USERNAME, equalTo(testUser.getUsername()))
-      .body(FAILED_USERS + "[0]." + USER_ERROR_MESSAGE,
-        equalTo(UserImportAPIConstants.FAILED_TO_CREATE_NEW_USER_WITH_EXTERNAL_SYSTEM_ID + testUser.getExternalSystemId()))
+      .body(FAILED_RECORDS, equalTo(0))
       .statusCode(200);
   }
 

--- a/src/test/resources/mock_import_with_address_add.json
+++ b/src/test/resources/mock_import_with_address_add.json
@@ -115,7 +115,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28user_address%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22user_address%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_import_with_address_rewrite.json
+++ b/src/test/resources/mock_import_with_address_rewrite.json
@@ -115,7 +115,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28user2_address2%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22user2_address2%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_import_with_address_update.json
+++ b/src/test/resources/mock_import_with_address_update.json
@@ -115,7 +115,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28user_address%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22user_address%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_import_with_existing_address.json
+++ b/src/test/resources/mock_import_with_existing_address.json
@@ -115,7 +115,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28user_address%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22user_address%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_multiple_user_creation.json
+++ b/src/test/resources/mock_multiple_user_creation.json
@@ -115,7 +115,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%2811_12+or+21_22+or+31_32+or+41_42+or+51_52+or+61_62+or+71_72+or+81_82+or+91_92+or+101_102%29&limit=20&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%2211_12%22+or+%2221_22%22+or+%2231_32%22+or+%2241_42%22+or+%2251_52%22+or+%2261_62%22+or+%2271_72%22+or+%2281_82%22+or+%2291_92%22+or+%22101_102%22%29&limit=20&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_prefixed_user_creation.json
+++ b/src/test/resources/mock_prefixed_user_creation.json
@@ -115,7 +115,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28test_test_user%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22test_test_user%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_prefixed_user_update.json
+++ b/src/test/resources/mock_prefixed_user_update.json
@@ -115,7 +115,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28test2_user2_update2%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22test2_user2_update2%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_user_creation.json
+++ b/src/test/resources/mock_user_creation.json
@@ -115,7 +115,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22amy_cabble%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_user_creation_error.json
+++ b/src/test/resources/mock_user_creation_error.json
@@ -115,7 +115,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28error_error%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22error_error%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_user_creation_with_custom_fields.json
+++ b/src/test/resources/mock_user_creation_with_custom_fields.json
@@ -118,7 +118,7 @@
       }
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22amy_cabble%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_user_creation_with_custom_fields_failed_get.json
+++ b/src/test/resources/mock_user_creation_with_custom_fields_failed_get.json
@@ -75,7 +75,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22amy_cabble%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_user_creation_with_existng_department.json
+++ b/src/test/resources/mock_user_creation_with_existng_department.json
@@ -128,7 +128,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22amy_cabble%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_user_creation_with_masked_externalsystemid.json
+++ b/src/test/resources/mock_user_creation_with_masked_externalsystemid.json
@@ -75,7 +75,47 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28+or+%29&limit=4&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/service-points?limit=2147483647",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "servicepoints": [{
+          "id": "59646a99-4074-4ee5-bfd4-86f3fc7717da",
+          "name": "Test one"
+        },
+          {
+            "id": "b3e8cd45-dd4b-477c-b194-23b9a3afe4cc",
+            "name": "Test two"
+          },
+          {
+            "id": "179c85ac-aef3-4466-8310-30094bc750ce",
+            "name": "Test three"
+          }
+        ]
+      }
+    },
+    {
+      "url": "/departments?limit=2147483647",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "departments": [],
+        "totalRecords": 0
+      }
+    },
+    {
+      "url": "/custom-fields?limit=2147483647",
+      "method": "get",
+      "status": 200,
+      "receivedData": {
+        "customFields": [],
+        "totalRecords": 0
+      },
+      "receivedPath": "",
+      "sendData": {}
+    },
+    {
+      "url": "/users?query=externalSystemId%3D%3D%28%22amy%2Fcab%5C%2Able%22+or+%22amy%2Fcab%5C%2Able%22%29&limit=4&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {
@@ -92,7 +132,7 @@
       "receivedData": {
         "id": "1ad737b0-d847-11e6-bf26-cec0c932ce01",
         "proxyFor": [],
-        "externalSystemId": "amy_cabble",
+        "externalSystemId": "amy/cab*ble",
         "personal": {
           "firstName": "Amy",
           "lastName": "Cabble",
@@ -107,7 +147,7 @@
       },
       "receivedPath": "",
       "sendData": {
-        "externalSystemId": "amy_cabble",
+        "externalSystemId": "amy/cab*ble",
         "personal": {
           "firstName": "Amy",
           "lastName": "Cabble",
@@ -130,26 +170,6 @@
         "userId": "1ad737b0-d847-11e6-bf26-cec0c932ce01",
         "permissions": []
       }
-    },
-    {
-      "url": "/departments?limit=2147483647",
-      "method": "get",
-      "status": 200,
-      "receivedData": {
-        "departments": [],
-        "totalRecords": 0
-      }
-    },
-    {
-      "url": "/custom-fields?limit=2147483647",
-      "method": "get",
-      "status": 200,
-      "receivedData": {
-        "customFields": [],
-        "totalRecords": 0
-      },
-      "receivedPath": "",
-      "sendData": {}
     }
-  ]
+   ]
 }

--- a/src/test/resources/mock_user_creation_with_multi_custom_fields.json
+++ b/src/test/resources/mock_user_creation_with_multi_custom_fields.json
@@ -105,7 +105,7 @@
       }
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22amy_cabble%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_user_creation_with_new_department.json
+++ b/src/test/resources/mock_user_creation_with_new_department.json
@@ -142,7 +142,7 @@
       }
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22amy_cabble%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_user_creation_with_new_preference.json
+++ b/src/test/resources/mock_user_creation_with_new_preference.json
@@ -95,7 +95,7 @@
       }
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22amy_cabble%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_user_creation_with_non_existing_patron_group.json
+++ b/src/test/resources/mock_user_creation_with_non_existing_patron_group.json
@@ -115,7 +115,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22amy_cabble%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_user_creation_with_permission_error.json
+++ b/src/test/resources/mock_user_creation_with_permission_error.json
@@ -115,7 +115,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22amy_cabble%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_user_creation_with_update_department.json
+++ b/src/test/resources/mock_user_creation_with_update_department.json
@@ -137,7 +137,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22amy_cabble%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_user_creation_without_personal_data.json
+++ b/src/test/resources/mock_user_creation_without_personal_data.json
@@ -115,7 +115,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22amy_cabble%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_user_search_error.json
+++ b/src/test/resources/mock_user_search_error.json
@@ -115,7 +115,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22amy_cabble%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 500,
       "receivedData": "Internal server error.",

--- a/src/test/resources/mock_user_update.json
+++ b/src/test/resources/mock_user_update.json
@@ -115,7 +115,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28user_update%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22user_update%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_user_update_error.json
+++ b/src/test/resources/mock_user_update_error.json
@@ -115,7 +115,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28user_update%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22user_update%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_user_update_not_existed_custom_field.json
+++ b/src/test/resources/mock_user_update_not_existed_custom_field.json
@@ -75,7 +75,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28amy_cabble%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22amy_cabble%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_user_update_with_existing_departments.json
+++ b/src/test/resources/mock_user_update_with_existing_departments.json
@@ -128,7 +128,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28user_update%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22user_update%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_user_update_with_new_preference_creation.json
+++ b/src/test/resources/mock_user_update_with_new_preference_creation.json
@@ -115,7 +115,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28user_update%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22user_update%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_user_update_with_no_user_preference.json
+++ b/src/test/resources/mock_user_update_with_no_user_preference.json
@@ -115,7 +115,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28user_update%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22user_update%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_user_update_with_preference_delete.json
+++ b/src/test/resources/mock_user_update_with_preference_delete.json
@@ -115,7 +115,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28user_update%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22user_update%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_user_update_with_preference_not_delete.json
+++ b/src/test/resources/mock_user_update_with_preference_not_delete.json
@@ -115,7 +115,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28user_update%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22user_update%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_user_update_with_preference_update.json
+++ b/src/test/resources/mock_user_update_with_preference_update.json
@@ -115,7 +115,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28user_update%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22user_update%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {

--- a/src/test/resources/mock_user_update_with_wrong_user_schema_in_search_result.json
+++ b/src/test/resources/mock_user_update_with_wrong_user_schema_in_search_result.json
@@ -115,7 +115,7 @@
       "sendData": {}
     },
     {
-      "url": "/users?query=externalSystemId%3D%3D%28user_update%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
+      "url": "/users?query=externalSystemId%3D%3D%28%22user_update%22%29&limit=2&offset=0&orderBy=externalSystemId&order=asc",
       "method": "get",
       "status": 200,
       "receivedData": {


### PR DESCRIPTION
The externalSystemId may contain special characters.

When building the CQL search query for the /users API put the externalSystemId into quotes and mask any special CQL characters to avoid any CQL injection.