### PR TITLE
MODUIMP-93: Pass error message from other modules (mod-users, ...)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -62,6 +62,13 @@
         <scope>import</scope>
       </dependency>
       <dependency>
+        <groupId>org.junit</groupId>
+        <artifactId>junit-bom</artifactId>
+        <version>5.10.2</version>
+        <type>pom</type>
+        <scope>import</scope>
+      </dependency>
+      <dependency>
         <groupId>org.testcontainers</groupId>
         <artifactId>testcontainers-bom</artifactId>
         <version>1.19.1</version>
@@ -123,6 +130,16 @@
     <dependency>
       <groupId>io.vertx</groupId>
       <artifactId>vertx-unit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.vertx</groupId>
+      <artifactId>vertx-junit5</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.junit.vintage</groupId>
+      <artifactId>junit-vintage-engine</artifactId>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -411,6 +428,12 @@
             </configuration>
           </execution>
         </executions>
+      </plugin>
+
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>3.1.2</version>
       </plugin>
 
       <plugin>

--- a/src/main/java/org/folio/rest/impl/UserImportAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserImportAPI.java
@@ -13,6 +13,9 @@ import static org.folio.rest.impl.UserImportAPIConstants.USERS_ENDPOINT;
 import static org.folio.rest.impl.UserImportAPIConstants.USERS_WERE_IMPORTED_SUCCESSFULLY;
 import static org.folio.rest.impl.UserImportAPIConstants.USER_DEACTIVATION_SKIPPED;
 import static org.folio.rest.impl.UserImportAPIConstants.USER_SCHEMA_MISMATCH;
+import static org.folio.rest.validator.ChattyResponsePredicate.SC_OK;
+import static org.folio.rest.validator.ChattyResponsePredicate.SC_CREATED;
+import static org.folio.rest.validator.ChattyResponsePredicate.SC_NO_CONTENT;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -38,7 +41,6 @@ import io.vertx.core.json.JsonArray;
 import io.vertx.core.json.JsonObject;
 import io.vertx.ext.web.RoutingContext;
 import io.vertx.ext.web.client.HttpResponse;
-import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 
@@ -315,7 +317,7 @@ public class UserImportAPI implements UserImport {
     userQueryBuilder.append(")");
     final String userSearchQuery = generateUserSearchQuery(userQueryBuilder.toString(), users.size() * 2, 0);
     return HttpClientUtil.getRequestOkapi(HttpMethod.GET, okapiHeaders, userSearchQuery)
-        .expect(ResponsePredicate.SC_OK)
+        .expect(SC_OK)
         .send()
         .map(res -> getUsersFromResult(res.bodyAsJsonObject()))
         .recover(e -> HttpClientUtil.errorManagement(e, FAILED_TO_PROCESS_USER_SEARCH_RESPONSE));
@@ -414,7 +416,7 @@ public class UserImportAPI implements UserImport {
     final String userUpdateQuery = UriBuilder.fromPath(USERS_ENDPOINT + "/" + user.getId()).build().toString();
 
     return HttpClientUtil.getRequestOkapi(HttpMethod.PUT, okapiHeaders, userUpdateQuery)
-        .expect(ResponsePredicate.SC_NO_CONTENT)
+        .expect(SC_NO_CONTENT)
         .sendJson(JsonObject.mapFrom(user))
         .map(x -> SingleUserImportResponse.updated(user.getExternalSystemId()))
         .recover(e -> HttpClientUtil.errorManagement(e, FAILED_TO_UPDATE_USER_WITH_EXTERNAL_SYSTEM_ID
@@ -437,7 +439,7 @@ public class UserImportAPI implements UserImport {
     return addEmptyPermissionSetForUser(okapiHeaders, user)
         .compose(x ->
           HttpClientUtil.getRequestOkapi(HttpMethod.POST, okapiHeaders, userCreationQuery)
-            .expect(ResponsePredicate.SC_CREATED)
+            .expect(SC_CREATED)
             .sendJsonObject(JsonObject.mapFrom(user))
             .map(res -> SingleUserImportResponse.created(user.getExternalSystemId())))
         .onFailure(e -> LOGGER.error(() -> "create new user: " + e.getMessage(), e))
@@ -496,7 +498,7 @@ public class UserImportAPI implements UserImport {
     final String permissionAddQuery = UriBuilder.fromPath(PERMS_USERS_ENDPOINT).build().toString();
 
     return HttpClientUtil.getRequestOkapi(HttpMethod.POST, okapiHeaders, permissionAddQuery)
-        .expect(ResponsePredicate.SC_CREATED)
+        .expect(SC_CREATED)
         .sendJsonObject(object)
         .map(HttpResponse::bodyAsJsonObject)
         .recover(e -> HttpClientUtil.errorManagement(e, FAILED_TO_ADD_PERMISSIONS_FOR_USER_WITH_EXTERNAL_SYSTEM_ID
@@ -519,7 +521,7 @@ public class UserImportAPI implements UserImport {
     int limit = 10;
     final String userSearchQuery = generateUserSearchQuery(query, limit, 0);
     return HttpClientUtil.getRequestOkapi(HttpMethod.GET, okapiHeaders, userSearchQuery)
-        .expect(ResponsePredicate.SC_OK)
+        .expect(SC_OK)
         .send()
         .compose(res -> listAllUsers(res.bodyAsJsonObject(), okapiHeaders, query, limit))
         .recover(e -> HttpClientUtil.errorManagement(e, FAILED_TO_PROCESS_USER_SEARCH_RESULT));
@@ -559,7 +561,7 @@ public class UserImportAPI implements UserImport {
 
     final String userSearchQuery = generateUserSearchQuery(query, limit, offset);
     return HttpClientUtil.getRequestOkapi(HttpMethod.GET, okapiHeaders, userSearchQuery)
-        .expect(ResponsePredicate.SC_OK)
+        .expect(SC_OK)
         .send()
         .<Void>map(
             res -> {

--- a/src/main/java/org/folio/rest/validator/ChattyResponsePredicate.java
+++ b/src/main/java/org/folio/rest/validator/ChattyResponsePredicate.java
@@ -9,8 +9,8 @@ import io.vertx.ext.web.client.predicate.ResponsePredicate;
 /**
  * The same as {@link ResponsePredicate} but with response body included in the Exception message.
  */
-public interface ChattyResponsePredicate {
-  ErrorConverter errorConverter = ErrorConverter.createFullBody(result -> {
+public final class ChattyResponsePredicate {
+  private static final ErrorConverter CONVERTER = ErrorConverter.createFullBody(result -> {
     String message = result.message() + " - " + result.response().bodyAsString();
     return new NoStackTraceThrowable(message);
   });
@@ -18,15 +18,18 @@ public interface ChattyResponsePredicate {
   /**
    * 200 OK
    */
-  ResponsePredicate SC_OK = create(ResponsePredicate.SC_OK, errorConverter);
+  public static final ResponsePredicate SC_OK = create(ResponsePredicate.SC_OK, CONVERTER);
 
   /**
    * 201 Created
    */
-  ResponsePredicate SC_CREATED = create(ResponsePredicate.SC_CREATED, errorConverter);
+  public static final ResponsePredicate SC_CREATED = create(ResponsePredicate.SC_CREATED, CONVERTER);
 
   /**
    * 204 No Content
    */
-  ResponsePredicate SC_NO_CONTENT = create(ResponsePredicate.SC_NO_CONTENT, errorConverter);
+  public static final ResponsePredicate SC_NO_CONTENT = create(ResponsePredicate.SC_NO_CONTENT, CONVERTER);
+
+  private ChattyResponsePredicate() {
+  }
 }

--- a/src/main/java/org/folio/rest/validator/ChattyResponsePredicate.java
+++ b/src/main/java/org/folio/rest/validator/ChattyResponsePredicate.java
@@ -1,0 +1,32 @@
+package org.folio.rest.validator;
+
+import static io.vertx.ext.web.client.predicate.ResponsePredicate.create;
+
+import io.vertx.core.impl.NoStackTraceThrowable;
+import io.vertx.ext.web.client.predicate.ErrorConverter;
+import io.vertx.ext.web.client.predicate.ResponsePredicate;
+
+/**
+ * The same as {@link ResponsePredicate} but with response body included in the Exception message.
+ */
+public interface ChattyResponsePredicate {
+  ErrorConverter errorConverter = ErrorConverter.createFullBody(result -> {
+    String message = result.message() + " - " + result.response().bodyAsString();
+    return new NoStackTraceThrowable(message);
+  });
+
+  /**
+   * 200 OK
+   */
+  ResponsePredicate SC_OK = create(ResponsePredicate.SC_OK, errorConverter);
+
+  /**
+   * 201 Created
+   */
+  ResponsePredicate SC_CREATED = create(ResponsePredicate.SC_CREATED, errorConverter);
+
+  /**
+   * 204 No Content
+   */
+  ResponsePredicate SC_NO_CONTENT = create(ResponsePredicate.SC_NO_CONTENT, errorConverter);
+}

--- a/src/main/java/org/folio/service/AddressTypeService.java
+++ b/src/main/java/org/folio/service/AddressTypeService.java
@@ -3,6 +3,7 @@ package org.folio.service;
 import static org.folio.rest.impl.UserImportAPIConstants.ADDRESS_TYPES_ENDPOINT;
 import static org.folio.rest.impl.UserImportAPIConstants.FAILED_TO_LIST_ADDRESS_TYPES;
 import static org.folio.rest.impl.UserImportAPIConstants.LIMIT_ALL;
+import static org.folio.rest.validator.ChattyResponsePredicate.SC_OK;
 
 import java.util.Map;
 
@@ -10,7 +11,6 @@ import io.vertx.core.Future;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
 
-import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import org.folio.util.HttpClientUtil;
 import org.folio.util.JsonObjectUtil;
 
@@ -21,7 +21,7 @@ public class AddressTypeService {
 
   public Future<Map<String, String>> getAddressTypes(Map<String, String> okapiHeaders) {
     return HttpClientUtil.getRequestOkapi(HttpMethod.GET, okapiHeaders, ADDRESS_TYPES_ENDPOINT + LIMIT_ALL)
-        .expect(ResponsePredicate.SC_OK)
+        .expect(SC_OK)
         .send()
         .map(res -> extractAddressTypes(res.bodyAsJsonObject()))
         .recover(e -> HttpClientUtil.errorManagement(e, FAILED_TO_LIST_ADDRESS_TYPES));

--- a/src/main/java/org/folio/service/CustomFieldsService.java
+++ b/src/main/java/org/folio/service/CustomFieldsService.java
@@ -6,6 +6,8 @@ import static org.folio.rest.impl.UserImportAPIConstants.FAILED_TO_LIST_CUSTOM_F
 import static org.folio.rest.impl.UserImportAPIConstants.FAILED_TO_UPDATE_CUSTOM_FIELD;
 import static org.folio.rest.impl.UserImportAPIConstants.LIMIT_ALL;
 import static org.folio.rest.impl.UserImportAPIConstants.CUSTOM_FIELDS_INTERFACE_NAME;
+import static org.folio.rest.validator.ChattyResponsePredicate.SC_OK;
+import static org.folio.rest.validator.ChattyResponsePredicate.SC_NO_CONTENT;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -19,7 +21,6 @@ import io.vertx.core.Future;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import org.apache.commons.collections4.map.CaseInsensitiveMap;
 import org.apache.commons.lang3.ObjectUtils;
 import org.apache.commons.lang3.StringUtils;
@@ -136,7 +137,7 @@ public class CustomFieldsService {
   private Future<Void> updateCustomField(CustomField customField, Map<String, String> okapiHeaders) {
     String query = CUSTOM_FIELDS_ENDPOINT + "/" + customField.getId();
     return HttpClientUtil.getRequestOkapi(HttpMethod.PUT, okapiHeaders, query)
-        .expect(ResponsePredicate.SC_NO_CONTENT)
+        .expect(SC_NO_CONTENT)
         .sendJson(customField)
         .recover(e -> HttpClientUtil.errorManagement(e, FAILED_TO_UPDATE_CUSTOM_FIELD))
         .mapEmpty();
@@ -160,7 +161,7 @@ public class CustomFieldsService {
 
   private Future<Set<CustomField>> getCustomFields(Map<String, String> headers) {
     return HttpClientUtil.getRequestOkapi(HttpMethod.GET, headers, CUSTOM_FIELDS_ENDPOINT + LIMIT_ALL)
-        .expect(ResponsePredicate.SC_OK)
+        .expect(SC_OK)
         .send()
         .map(res -> extractCustomFields(res.bodyAsJsonObject()))
         .recover(e -> HttpClientUtil.errorManagement(e, FAILED_TO_LIST_CUSTOM_FIELDS));

--- a/src/main/java/org/folio/service/DepartmentsService.java
+++ b/src/main/java/org/folio/service/DepartmentsService.java
@@ -5,6 +5,9 @@ import static io.vertx.core.Future.succeededFuture;
 import static org.folio.rest.impl.UserImportAPIConstants.DEPARTMENTS_ENDPOINT;
 import static org.folio.rest.impl.UserImportAPIConstants.FAILED_TO_LIST_DEPARTMENTS;
 import static org.folio.rest.impl.UserImportAPIConstants.LIMIT_ALL;
+import static org.folio.rest.validator.ChattyResponsePredicate.SC_OK;
+import static org.folio.rest.validator.ChattyResponsePredicate.SC_CREATED;
+import static org.folio.rest.validator.ChattyResponsePredicate.SC_NO_CONTENT;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -17,7 +20,6 @@ import io.vertx.core.Future;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.Json;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import org.apache.commons.lang3.StringUtils;
 
 import org.folio.model.UserImportData;
@@ -81,7 +83,7 @@ public class DepartmentsService {
 
   private Future<Set<Department>> getDepartments(Map<String, String> okapiHeaders) {
     return HttpClientUtil.getRequestOkapi(HttpMethod.GET, okapiHeaders, DEPARTMENTS_ENDPOINT + LIMIT_ALL)
-        .expect(ResponsePredicate.SC_OK)
+        .expect(SC_OK)
         .send()
         .map(res -> extractDepartments(res.bodyAsJsonObject()))
         .recover(e -> HttpClientUtil.errorManagement(e, FAILED_TO_LIST_DEPARTMENTS));
@@ -92,7 +94,7 @@ public class DepartmentsService {
       department.setCode(generateCode(department.getName()));
     }
     return HttpClientUtil.getRequestOkapi(HttpMethod.POST, okapiHeaders, DEPARTMENTS_ENDPOINT)
-        .expect(ResponsePredicate.SC_CREATED)
+        .expect(SC_CREATED)
         .sendJsonObject(JsonObject.mapFrom(department))
         .map(res -> res.bodyAsJsonObject().mapTo(Department.class))
         .recover(e -> HttpClientUtil.errorManagement(e, FAILED_TO_CREATE_DEPARTMENT_MESSAGE));
@@ -100,7 +102,7 @@ public class DepartmentsService {
 
   private Future<Void> updateDepartment(Department existed, Department updated, Map<String, String> okapiHeaders) {
     return HttpClientUtil.getRequestOkapi(HttpMethod.PUT, okapiHeaders, DEPARTMENTS_ENDPOINT + "/" + existed.getId())
-        .expect(ResponsePredicate.SC_NO_CONTENT)
+        .expect(SC_NO_CONTENT)
         .sendJsonObject(JsonObject.mapFrom(updated))
         .recover(e -> HttpClientUtil.errorManagement(e, FAILED_TO_UPDATE_DEPARTMENT_MESSAGE))
         .mapEmpty();

--- a/src/main/java/org/folio/service/PatronGroupService.java
+++ b/src/main/java/org/folio/service/PatronGroupService.java
@@ -3,13 +3,13 @@ package org.folio.service;
 import static org.folio.rest.impl.UserImportAPIConstants.FAILED_TO_LIST_PATRON_GROUPS;
 import static org.folio.rest.impl.UserImportAPIConstants.LIMIT_ALL;
 import static org.folio.rest.impl.UserImportAPIConstants.PATRON_GROUPS_ENDPOINT;
+import static org.folio.rest.validator.ChattyResponsePredicate.SC_OK;
 
 import java.util.Map;
 
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import org.folio.util.HttpClientUtil;
 import org.folio.util.JsonObjectUtil;
 
@@ -22,7 +22,7 @@ public class PatronGroupService {
     final String query = PATRON_GROUPS_ENDPOINT + LIMIT_ALL;
 
     return HttpClientUtil.getRequestOkapi(HttpMethod.GET, okapiHeaders, query)
-        .expect(ResponsePredicate.SC_OK)
+        .expect(SC_OK)
         .send()
         .map(res -> extractPatronGroups(res.bodyAsJsonObject()))
         .recover(e -> HttpClientUtil.errorManagement(e, FAILED_TO_LIST_PATRON_GROUPS));

--- a/src/main/java/org/folio/service/ServicePointsService.java
+++ b/src/main/java/org/folio/service/ServicePointsService.java
@@ -3,13 +3,13 @@ package org.folio.service;
 import static org.folio.rest.impl.UserImportAPIConstants.FAILED_TO_LIST_SERVICE_POINTS;
 import static org.folio.rest.impl.UserImportAPIConstants.LIMIT_ALL;
 import static org.folio.rest.impl.UserImportAPIConstants.SERVICE_POINTS_ENDPOINT;
+import static org.folio.rest.validator.ChattyResponsePredicate.SC_OK;
 
 import java.util.Map;
 
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import org.folio.util.HttpClientUtil;
 import org.folio.util.JsonObjectUtil;
 
@@ -21,7 +21,7 @@ public class ServicePointsService {
 
   public Future<Map<String, String>> getServicePoints(Map<String, String> okapiHeaders) {
     return HttpClientUtil.getRequestOkapi(HttpMethod.GET, okapiHeaders, SERVICE_POINTS_ENDPOINT + LIMIT_ALL)
-        .expect(ResponsePredicate.SC_OK)
+        .expect(SC_OK)
         .send()
         .map(res -> extractServicePoints(res.bodyAsJsonObject()))
         .recover(e -> HttpClientUtil.errorManagement(e, FAILED_TO_LIST_SERVICE_POINTS));

--- a/src/main/java/org/folio/service/UserPreferenceService.java
+++ b/src/main/java/org/folio/service/UserPreferenceService.java
@@ -6,6 +6,9 @@ import static org.folio.rest.impl.UserImportAPIConstants.FAILED_TO_UPDATE_USER_P
 import static org.folio.rest.impl.UserImportAPIConstants.FAILED_USER_PREFERENCE_VALIDATION;
 import static org.folio.rest.impl.UserImportAPIConstants.REQUEST_PREFERENCES_ENDPOINT;
 import static org.folio.rest.impl.UserImportAPIConstants.REQUEST_PREFERENCES_SEARCH_QUERY_ENDPOINT;
+import static org.folio.rest.validator.ChattyResponsePredicate.SC_OK;
+import static org.folio.rest.validator.ChattyResponsePredicate.SC_CREATED;
+import static org.folio.rest.validator.ChattyResponsePredicate.SC_NO_CONTENT;
 
 import java.util.Map;
 
@@ -14,7 +17,6 @@ import javax.validation.ValidationException;
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonObject;
-import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import org.apache.logging.log4j.LogManager;
 import org.apache.logging.log4j.Logger;
 import org.jetbrains.annotations.NotNull;
@@ -32,7 +34,7 @@ public class UserPreferenceService {
   public Future<RequestPreference> get(Map<String, String> okapiHeaders, String userId) {
     String query = String.format(REQUEST_PREFERENCES_SEARCH_QUERY_ENDPOINT, "?query=userId==" + userId);
     return HttpClientUtil.getRequestOkapi(HttpMethod.GET, okapiHeaders, query)
-        .expect(ResponsePredicate.SC_OK)
+        .expect(SC_OK)
         .send()
         .map(res -> res.bodyAsJsonObject().getJsonArray(REQUEST_PREFERENCES_ARRAY_KEY)
             .getJsonObject(0).mapTo(RequestPreference.class))
@@ -42,7 +44,7 @@ public class UserPreferenceService {
   public Future<Void> update(Map<String, String> okapiHeaders, RequestPreference entity) {
     String query = String.format(REQUEST_PREFERENCES_SEARCH_QUERY_ENDPOINT, "/" + entity.getId());
     return HttpClientUtil.getRequestOkapi(HttpMethod.PUT, okapiHeaders, query)
-        .expect(ResponsePredicate.SC_NO_CONTENT)
+        .expect(SC_NO_CONTENT)
         .sendJsonObject(JsonObject.mapFrom(entity))
         .recover(e -> HttpClientUtil.errorManagement(e, FAILED_TO_UPDATE_USER_PREFERENCE))
         .mapEmpty();
@@ -51,7 +53,7 @@ public class UserPreferenceService {
   public Future<Void> delete(Map<String, String> okapiHeaders, String id) {
     String query = String.format(REQUEST_PREFERENCES_SEARCH_QUERY_ENDPOINT, "/" + id);
     return HttpClientUtil.getRequestOkapi(HttpMethod.DELETE, okapiHeaders, query)
-        .expect(ResponsePredicate.SC_NO_CONTENT)
+        .expect(SC_NO_CONTENT)
         .send()
         .recover(e -> HttpClientUtil.errorManagement(e, FAILED_TO_DELETE_USER_PREFERENCE))
         .mapEmpty();
@@ -59,7 +61,7 @@ public class UserPreferenceService {
 
   public Future<RequestPreference> create(Map<String, String> okapiHeaders, RequestPreference entity) {
     return HttpClientUtil.getRequestOkapi(HttpMethod.POST, okapiHeaders, REQUEST_PREFERENCES_ENDPOINT)
-        .expect(ResponsePredicate.SC_CREATED)
+        .expect(SC_CREATED)
         .sendJsonObject(JsonObject.mapFrom(entity))
         .map(res -> res.bodyAsJsonObject().mapTo(RequestPreference.class))
         .recover(e -> HttpClientUtil.errorManagement(e, FAILED_TO_CREATE_USER_PREFERENCE));

--- a/src/main/java/org/folio/util/OkapiUtil.java
+++ b/src/main/java/org/folio/util/OkapiUtil.java
@@ -1,6 +1,7 @@
 package org.folio.util;
 
 import static org.folio.rest.impl.UserImportAPIConstants.GET_MODULES_WITH_INTERFACE;
+import static org.folio.rest.validator.ChattyResponsePredicate.SC_OK;
 
 import java.util.List;
 import java.util.Map;
@@ -10,7 +11,6 @@ import java.util.stream.IntStream;
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonArray;
-import io.vertx.ext.web.client.predicate.ResponsePredicate;
 import org.folio.rest.tools.utils.TenantTool;
 
 public final class OkapiUtil {
@@ -22,7 +22,7 @@ public final class OkapiUtil {
 
     String requestUri = String.format(GET_MODULES_WITH_INTERFACE, TenantTool.tenantId(okapiHeaders), interfaceName);
     return HttpClientUtil.getRequestOkapi(HttpMethod.GET, okapiHeaders, requestUri)
-        .expect(ResponsePredicate.SC_OK)
+        .expect(SC_OK)
         .send()
         .map(res -> extractModuleIds(res.bodyAsJsonArray()))
         .recover(e -> HttpClientUtil.errorManagement(e, "Failed to get modules providing interface " + interfaceName));

--- a/src/test/java/org/folio/rest/validator/ChattyResponsePredicateTest.java
+++ b/src/test/java/org/folio/rest/validator/ChattyResponsePredicateTest.java
@@ -1,0 +1,46 @@
+package org.folio.rest.validator;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+
+import io.vertx.core.Vertx;
+import io.vertx.ext.web.client.WebClient;
+import io.vertx.ext.web.client.predicate.ResponsePredicate;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+import java.util.stream.Stream;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+@ExtendWith(VertxExtension.class)
+class ChattyResponsePredicateTest {
+
+  static Stream<Arguments> predicate() {
+    return Stream.of(
+        arguments(ChattyResponsePredicate.SC_OK, 200),
+        arguments(ChattyResponsePredicate.SC_CREATED, 201),
+        arguments(ChattyResponsePredicate.SC_NO_CONTENT, 204)
+        );
+  }
+
+  @ParameterizedTest
+  @MethodSource
+  void predicate(ResponsePredicate predicate, Integer status, Vertx vertx, VertxTestContext vtc) {
+    vertx.createHttpServer()
+    .requestHandler(request -> request.response().setStatusCode(555).end("Body and Soul"))
+    .listen(0)
+    .compose(httpServer -> WebClient.create(vertx)
+        .post(httpServer.actualPort(), "localhost", "/")
+        .expect(predicate)
+        .send())
+    .onComplete(vtc.failing(e -> {
+      var expected = "Response status code 555 is not equal to " + status + " - Body and Soul";
+      assertThat(e.getMessage(), is(expected));
+      vtc.completeNow();
+    }));
+  }
+
+}


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODUIMP-93

ResponsePredicate suppresses the error message that other modules report in the HTTP body of a failure.

Only the HTTP status code like 422 is reported.

Fix: Pass the body as suggested in
https://vertx.io/docs/vertx-web-client/java/#_creating_custom_failures