### PR TITLE
MODUIMP-95: Add preferredEmailCommunication and profilePictureLink

### DIFF
--- a/ramls/schemas/userdataimport.json
+++ b/ramls/schemas/userdataimport.json
@@ -1,7 +1,7 @@
 {
   "$schema": "http://json-schema.org/draft-04/schema#",
   "title": "User Schema",
-  "description": "A user",
+  "description": "A user; the same as used for /users API but with \"requestPreference\" property and \"require\" restriction added, and \"patronGroups\", \"departments\", \"addressTypeId\" and \"preferredContactTypeId\" are names and not UUIDs.",
   "type": "object",
   "properties": {
     "username": {
@@ -13,19 +13,19 @@
       "type": "string"
     },
     "externalSystemId": {
-      "description": "An ID that corresponds to an external authority",
+      "description": "A unique ID that corresponds to an external authority",
       "type": "string"
     },
     "barcode": {
-      "description": "The library barcode for this user",
+      "description": "The unique library barcode for this user",
       "type": "string"
     },
     "active": {
-      "description": "A flag to determine if a user can log in, take out loans, etc.",
+      "description": "A flag to determine if the user's account is effective and not expired. The tenant configuration can require the user to be active for login. Active is different from the loan patron block",
       "type": "boolean"
     },
     "type": {
-      "description": "The class of user",
+      "description": "The class of user like staff or patron; this is different from patronGroup; it can store shadow, system user and dcb types also",
       "type": "string"
     },
     "patronGroup": {
@@ -138,6 +138,11 @@
         "preferredContactTypeId": {
           "description": "Name of user's preferred contact type. One of mail, email, text, phone, mobile.",
           "type": "string"
+        },
+        "profilePictureLink": {
+          "description": "Link to the profile picture",
+          "type": "string",
+          "format": "uri"
         }
       },
       "additionalProperties": false,
@@ -177,6 +182,16 @@
       "description": "Object that contains custom field",
       "type": "object",
       "additionalProperties": true
+    },
+    "preferredEmailCommunication": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "enum": ["Support", "Programs", "Services"]
+      },
+      "maxItems": 3,
+      "uniqueItems": true,
+      "description": "Preferred email communication types"
     },
 
 

--- a/ramls/schemas/userdataimport.json
+++ b/ramls/schemas/userdataimport.json
@@ -29,11 +29,11 @@
       "type": "string"
     },
     "patronGroup": {
-      "description": "The name of the patron group the user belongs to",
+      "description": "The name of the patron group the user belongs to; this is different from the patronGroup property of the /users API that is a UUID.",
       "type": "string"
     },
     "departments": {
-      "description": "List of names of the departments the user belongs to",
+      "description": "List of names of the departments the user belongs to; this is different from the departments property of the /users API this is a UUID.",
       "type": "array",
       "uniqueItems": true,
       "items": {
@@ -124,7 +124,7 @@
                 "type": "string"
               },
               "addressTypeId": {
-                "description": "The name of an address type object at the /addresstypes API.",
+                "description": "The name of an address type object at the /addresstypes API; this is different from the addressTypeId property of the /users API that is a UUID.",
                 "type": "string"
               },
               "primaryAddress": {
@@ -136,7 +136,7 @@
           }
         },
         "preferredContactTypeId": {
-          "description": "Name of user's preferred contact type. One of mail, email, text, phone, mobile.",
+          "description": "Name of user's preferred contact type. One of mail, email, text, phone, mobile.  This is different from the preferredContactTypeId property of the /users API that is a UUID.",
           "type": "string"
         },
         "profilePictureLink": {

--- a/src/main/java/org/folio/rest/impl/UserImportAPI.java
+++ b/src/main/java/org/folio/rest/impl/UserImportAPI.java
@@ -415,7 +415,7 @@ public class UserImportAPI implements UserImport {
 
     return HttpClientUtil.getRequestOkapi(HttpMethod.PUT, okapiHeaders, userUpdateQuery)
         .expect(ResponsePredicate.SC_NO_CONTENT)
-        .sendJson(JsonObject.mapFrom(user))
+        .sendJson(asJsonObject(user))
         .map(x -> SingleUserImportResponse.updated(user.getExternalSystemId()))
         .recover(e -> HttpClientUtil.errorManagement(e, FAILED_TO_UPDATE_USER_WITH_EXTERNAL_SYSTEM_ID
             + user.getExternalSystemId()));
@@ -438,11 +438,20 @@ public class UserImportAPI implements UserImport {
         .compose(x ->
           HttpClientUtil.getRequestOkapi(HttpMethod.POST, okapiHeaders, userCreationQuery)
             .expect(ResponsePredicate.SC_CREATED)
-            .sendJsonObject(JsonObject.mapFrom(user))
+            .sendJsonObject(asJsonObject(user))
             .map(res -> SingleUserImportResponse.created(user.getExternalSystemId())))
         .onFailure(e -> LOGGER.error(() -> "create new user: " + e.getMessage(), e))
         .otherwise(e -> SingleUserImportResponse.failed(user.getExternalSystemId(), user.getUsername(),
             500, FAILED_TO_CREATE_NEW_USER_WITH_EXTERNAL_SYSTEM_ID + user.getExternalSystemId()));
+  }
+
+  private JsonObject asJsonObject(User user) {
+    var jsonObject = JsonObject.mapFrom(user);
+    if (user.getPreferredEmailCommunication().isEmpty()) {
+      // delete optional array to be compatible with Poppy and Quesnelia versions of mod-users
+      jsonObject.remove("preferredEmailCommunication");
+    }
+    return jsonObject;
   }
 
   private Future<RequestPreference> createUserPreference(User user, UserImportData userImportData,


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODUIMP-95

https://folio-org.atlassian.net/browse/MODUSERS-459 has added “preferredEmailCommunication” to user schema in mod-users:

* https://github.com/folio-org/mod-users/pull/354/files
* https://github.com/folio-org/mod-users/pull/356/files

https://folio-org.atlassian.net/browse/MODUSERS-405 has added “profilePictureLink” to user schema in mod-users:

* https://github.com/folio-org/mod-users/pull/328/files

mod-user-import needs to update its copy of the user schema in userdataimport.json to accept these new properties.

In addition update some descriptions using clarified wording from mod-users.