### PR TITLE
MODUIMP-97: Failed to prepare custom fields Interface 'users'

### DIFF
--- a/src/main/java/org/folio/rest/impl/UserImportAPIConstants.java
+++ b/src/main/java/org/folio/rest/impl/UserImportAPIConstants.java
@@ -21,7 +21,6 @@ public class UserImportAPIConstants {
   public static final String FAILED_TO_DELETE_USER_PREFERENCE = "Failed to delete user preference.";
   public static final String FAILED_TO_UPDATE_CUSTOM_FIELD = "Failed to update custom field.";
   public static final String FAILED_USER_PREFERENCE_VALIDATION = "User Preference validation failed: ";
-  public static final String FAILED_TO_GET_USER_MODULE_ID = "Interface 'users' must be provided only by one module";
   public static final String ERROR_MESSAGE = " Error message: ";
   public static final String USERS_WERE_IMPORTED_SUCCESSFULLY = "Users were imported successfully.";
   public static final String USER_DEACTIVATION_SKIPPED = "Users were not deactivated because of import failures.";
@@ -31,6 +30,7 @@ public class UserImportAPIConstants {
   public static final String LIMIT_ALL = "?limit=" + Integer.MAX_VALUE;
   public static final String GET_MODULES_WITH_INTERFACE = "/_/proxy/tenants/%s/interfaces/%s";
   public static final String CUSTOM_FIELDS_INTERFACE_NAME = "custom-fields";
+  public static final String CUSTOM_FIELDS_MODULE_NAME = "mod-users";
 
   public static final String USERS_ENDPOINT = "/users";
   public static final String PERMS_USERS_ENDPOINT = "/perms/users";

--- a/src/main/java/org/folio/service/CustomFieldsService.java
+++ b/src/main/java/org/folio/service/CustomFieldsService.java
@@ -1,11 +1,11 @@
 package org.folio.service;
 
 import static org.folio.rest.impl.UserImportAPIConstants.CUSTOM_FIELDS_ENDPOINT;
-import static org.folio.rest.impl.UserImportAPIConstants.FAILED_TO_GET_USER_MODULE_ID;
+import static org.folio.rest.impl.UserImportAPIConstants.CUSTOM_FIELDS_INTERFACE_NAME;
+import static org.folio.rest.impl.UserImportAPIConstants.CUSTOM_FIELDS_MODULE_NAME;
 import static org.folio.rest.impl.UserImportAPIConstants.FAILED_TO_LIST_CUSTOM_FIELDS;
 import static org.folio.rest.impl.UserImportAPIConstants.FAILED_TO_UPDATE_CUSTOM_FIELD;
 import static org.folio.rest.impl.UserImportAPIConstants.LIMIT_ALL;
-import static org.folio.rest.impl.UserImportAPIConstants.CUSTOM_FIELDS_INTERFACE_NAME;
 import static org.folio.rest.validator.ChattyResponsePredicate.SC_OK;
 import static org.folio.rest.validator.ChattyResponsePredicate.SC_NO_CONTENT;
 
@@ -28,7 +28,6 @@ import org.apache.commons.lang3.StringUtils;
 import org.folio.model.UserImportData;
 import org.folio.model.exception.CustomFieldMappingFailedException;
 import org.folio.okapi.common.GenericCompositeFuture;
-import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.jaxrs.model.CheckboxField;
 import org.folio.rest.jaxrs.model.CustomField;
 import org.folio.rest.jaxrs.model.SelectFieldOption;
@@ -41,8 +40,7 @@ public class CustomFieldsService {
   public Future<Set<CustomField>> prepareCustomFields(UserImportData importData, Map<String, String> okapiHeaders) {
     Map<String, String> headers = new CaseInsensitiveMap<>(okapiHeaders);
 
-    return OkapiUtil.getModulesProvidingInterface(CUSTOM_FIELDS_INTERFACE_NAME, headers)
-      .compose(moduleIds -> updateHeaders(moduleIds, headers))
+    return OkapiUtil.setModuleIdForMultipleInterface(CUSTOM_FIELDS_INTERFACE_NAME, CUSTOM_FIELDS_MODULE_NAME, headers)
       .compose(o -> getCustomFields(headers))
       .compose(systemCustomFields -> {
         Set<CustomField> importCustomFields = importData.getCustomFields();
@@ -148,15 +146,6 @@ public class CustomFieldsService {
       return extractFunc.apply(o1);
     }
     return ObjectUtils.defaultIfNull(extractFunc.apply(o1), extractFunc.apply(o2));
-  }
-
-  private Future<Void> updateHeaders(List<String> moduleIds, Map<String, String> headers) {
-    if (moduleIds.size() != 1) {
-      return Future.failedFuture(FAILED_TO_GET_USER_MODULE_ID);
-    } else {
-      headers.put(XOkapiHeaders.MODULE_ID, moduleIds.get(0));
-      return Future.succeededFuture();
-    }
   }
 
   private Future<Set<CustomField>> getCustomFields(Map<String, String> headers) {

--- a/src/main/java/org/folio/util/OkapiUtil.java
+++ b/src/main/java/org/folio/util/OkapiUtil.java
@@ -11,6 +11,8 @@ import java.util.stream.IntStream;
 import io.vertx.core.Future;
 import io.vertx.core.http.HttpMethod;
 import io.vertx.core.json.JsonArray;
+import org.folio.okapi.common.ModuleId;
+import org.folio.okapi.common.XOkapiHeaders;
 import org.folio.rest.tools.utils.TenantTool;
 
 public final class OkapiUtil {
@@ -18,20 +20,44 @@ public final class OkapiUtil {
   private OkapiUtil() {
   }
 
-  public static Future<List<String>> getModulesProvidingInterface(String interfaceName, Map<String, String> okapiHeaders) {
+  /**
+   * Set the module id header for the interface.
+   *
+   * <p>See <a href="https://github.com/folio-org/okapi/blob/master/doc/guide.md#multiple-interfaces">
+   * multiple interfaces</a> documentation.
+   *
+   * @param interfaceName the interface with "interfaceType": "multiple", for example custom-fields
+   * @param moduleName the module name (product name) without version, for example mod-users
+   * @param okapiHeaders where to get the "X-Okapi-Tenant" header and where to write the "X-Okapi-Module-Id" header
+   * @return
+   */
+  public static Future<Void> setModuleIdForMultipleInterface(
+      String interfaceName, String moduleName, Map<String, String> okapiHeaders) {
 
     String requestUri = String.format(GET_MODULES_WITH_INTERFACE, TenantTool.tenantId(okapiHeaders), interfaceName);
     return HttpClientUtil.getRequestOkapi(HttpMethod.GET, okapiHeaders, requestUri)
         .expect(SC_OK)
         .send()
-        .map(res -> extractModuleIds(res.bodyAsJsonArray()))
-        .recover(e -> HttpClientUtil.errorManagement(e, "Failed to get modules providing interface " + interfaceName));
+        .compose(res -> {
+          var list = extractModuleIds(res.bodyAsJsonArray(), moduleName);
+          if (list.isEmpty()) {
+            return Future.failedFuture("No module found.");
+          }
+          if (list.size() != 1) {
+            return Future.failedFuture("Multiple modules found: " + list.toString());
+          }
+          okapiHeaders.put(XOkapiHeaders.MODULE_ID, list.get(0));
+          return Future.<Void>succeededFuture();
+        })
+        .recover(e -> HttpClientUtil.errorManagement(e,
+            "Failed to get module id for " + moduleName + " module providing interface " + interfaceName));
   }
 
-  private static List<String> extractModuleIds(JsonArray jsonArray) {
+  private static List<String> extractModuleIds(JsonArray jsonArray, String moduleName) {
     return IntStream.range(0, jsonArray.size())
         .mapToObj(jsonArray::getJsonObject)
         .map(o -> o.getString("id"))
+        .filter(moduleId -> new ModuleId(moduleId).getProduct().equals(moduleName))
         .distinct()
         .collect(Collectors.toList());
   }

--- a/src/test/java/org/folio/util/OkapiUtilTest.java
+++ b/src/test/java/org/folio/util/OkapiUtilTest.java
@@ -22,7 +22,6 @@ import io.vertx.junit5.VertxTestContext;
 class OkapiUtilTest {
 
   static String okapiUrl;
-  Map<String,String> headers;
 
   @RegisterExtension
   RunTestOnContext runTestOnContext = new RunTestOnContext();

--- a/src/test/java/org/folio/util/OkapiUtilTest.java
+++ b/src/test/java/org/folio/util/OkapiUtilTest.java
@@ -1,0 +1,119 @@
+package org.folio.util;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+
+import java.util.Map;
+import org.apache.commons.collections4.map.CaseInsensitiveMap;
+import org.folio.okapi.common.XOkapiHeaders;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.api.extension.RegisterExtension;
+
+import io.vertx.core.Future;
+import io.vertx.core.Vertx;
+import io.vertx.junit5.RunTestOnContext;
+import io.vertx.junit5.VertxExtension;
+import io.vertx.junit5.VertxTestContext;
+
+@ExtendWith(VertxExtension.class)
+class OkapiUtilTest {
+
+  static String okapiUrl;
+  Map<String,String> headers;
+
+  @RegisterExtension
+  RunTestOnContext runTestOnContext = new RunTestOnContext();
+
+  @BeforeAll
+  static void setUp(Vertx vertx, VertxTestContext vtc) {
+    vertx.createHttpServer()
+    .requestHandler(request -> {
+      switch (request.path()) {
+        case "/_/proxy/tenants/one/interfaces/custom-fields":
+          request.response().setStatusCode(200).end("""
+                          [{"id": "mod-orders-storage-13.8.0"}, {"id": "mod-users-1.2.3"}]
+                          """);
+          break;
+        case "/_/proxy/tenants/zero/interfaces/custom-fields":
+          request.response().setStatusCode(200).end("""
+                          []
+                          """);
+          break;
+        case "/_/proxy/tenants/two/interfaces/custom-fields":
+          request.response().setStatusCode(200).end("""
+                          [{"id": "mod-users-0.0.1"}, {"id": "mod-users-0.0.2"}]
+                          """);
+          break;
+        case "/_/proxy/tenants/diku/interfaces/500":
+          request.response().setStatusCode(500).end("big fail");
+          break;
+        default:
+          request.response().setStatusCode(404).end();
+      }
+
+    })
+    .listen(0)
+    .onComplete(vtc.succeeding(httpServer -> {
+      okapiUrl = "http://localhost:" + httpServer.actualPort();
+      vtc.completeNow();
+    }));
+  }
+
+  Future<String> setModuleIdForMultipleInterface(String tenantId, String interfaceName) {
+    var headers = new CaseInsensitiveMap<>(Map.of(
+        XOkapiHeaders.TENANT, tenantId,
+        XOkapiHeaders.URL, okapiUrl));
+    return OkapiUtil.setModuleIdForMultipleInterface(interfaceName, "mod-users", headers)
+        .map(x -> headers.get(XOkapiHeaders.MODULE_ID));
+  }
+
+  @Test
+  void one(VertxTestContext vtc) {
+    setModuleIdForMultipleInterface("one", "custom-fields")
+    .onComplete(vtc.succeeding(moduleId -> {
+      assertThat(moduleId, is("mod-users-1.2.3"));
+      vtc.completeNow();
+    }));
+  }
+
+  @Test
+  void zero(VertxTestContext vtc) {
+    setModuleIdForMultipleInterface("zero", "custom-fields")
+    .onComplete(vtc.failing(e -> {
+      assertThat(e.getMessage(), containsString("No module found"));
+      vtc.completeNow();
+    }));
+  }
+
+  @Test
+  void two(VertxTestContext vtc) {
+    setModuleIdForMultipleInterface("two", "custom-fields")
+    .onComplete(vtc.failing(e -> {
+      assertThat(e.getMessage(), containsString("Multiple modules found: [mod-users-0.0.1, mod-users-0.0.2]"));
+      vtc.completeNow();
+    }));
+  }
+
+  @Test
+  void status500(VertxTestContext vtc) {
+    setModuleIdForMultipleInterface("diku", "500")
+    .onComplete(vtc.failing(e -> {
+      assertThat(e.getMessage(), containsString("Response status code 500"));
+      assertThat(e.getMessage(), containsString("big fail"));
+      vtc.completeNow();
+    }));
+  }
+
+  @Test
+  void status404(VertxTestContext vtc) {
+    setModuleIdForMultipleInterface("diku", "404")
+    .onComplete(vtc.failing(e -> {
+      assertThat(e.getMessage(), containsString("Response status code 404"));
+      vtc.completeNow();
+    }));
+  }
+
+}


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODUIMP-97

Search for moduleId where module name equals mod-users.

This will skip mod-orders-storage that also has custom-fields interface.