### PR TITLE
MODUIMP-96: Rename permission, add folio-module-descriptor-validator

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -4,24 +4,15 @@
   "provides": [
     {
       "id": "user-import",
-      "version": "2.1",
+      "version": "2.2",
       "handlers": [
-        {
-          "methods": [
-            "GET"
-          ],
-          "pathPattern": "/user-import",
-          "permissionsRequired": [
-            "user-import.add"
-          ]
-        },
         {
           "methods": [
             "POST"
           ],
           "pathPattern": "/user-import",
           "permissionsRequired": [
-            "user-import.add"
+            "user-import.post"
           ],
           "modulePermissions": [
             "addresstypes.collection.get",
@@ -48,16 +39,19 @@
   ],
   "permissionSets": [
     {
-      "permissionName": "user-import.add",
+      "permissionName": "user-import.post",
       "displayName": "Import users",
-      "description": ""
+      "description": "",
+      "replaces": [
+        "user-import.add"
+      ]
     },
     {
       "permissionName": "user-import.all",
       "displayName": "User import - all permissions",
       "description": "",
       "subPermissions": [
-        "user-import.add"
+        "user-import.post"
       ],
       "visible": true
     }

--- a/pom.xml
+++ b/pom.xml
@@ -395,6 +395,19 @@
       </plugin>
 
       <plugin>
+        <groupId>org.folio</groupId>
+        <artifactId>folio-module-descriptor-validator</artifactId>
+        <version>1.0.0</version>
+        <executions>
+          <execution>
+            <goals>
+              <goal>validate</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+
+      <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-shade-plugin</artifactId>
         <version>3.5.1</version>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODUIMP-96

Rename permission user-import.add to user-import.post.

Remove GET /user-import API from module descriptor, it doesn't have an implementation.

Add folio-module-descriptor-validator to pom.xml.

No other module uses the permission name user-import.add: https://github.com/search?q=org%3Afolio-org+user-import.add&type=code