### PR TITLE
MODUIMP-100: Missing okapi interface dependency in module descriptor

### DIFF
--- a/descriptors/ModuleDescriptor-template.json
+++ b/descriptors/ModuleDescriptor-template.json
@@ -72,6 +72,10 @@
     {
       "id": "service-points",
       "version": "3.2"
+    },
+    {
+      "id": "okapi",
+      "version": "1.9"
     }
   ],
   "launchDescriptor": {


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODUIMP-100

https://github.com/folio-org/okapi/blob/v6.2.1/okapi-core/src/main/java/org/folio/okapi/managers/InternalModule.java#L120-L343