### PR TITLE
MODUIMP-103: Add personal.pronouns field

### DIFF
--- a/ramls/schemas/userdataimport.json
+++ b/ramls/schemas/userdataimport.json
@@ -55,6 +55,11 @@
       "description": "Personal information about the user",
       "type": "object",
       "properties": {
+        "pronouns": {
+          "description": "The user's pronouns",
+          "type": "string",
+          "maxLength": 300
+        },
         "lastName": {
           "description": "The user's surname",
           "type": "string"
@@ -140,7 +145,7 @@
           "type": "string"
         },
         "profilePictureLink": {
-          "description": "Link to the profile picture",
+          "description": "Link to the profile picture, or only the id of the /users/profile-picture entry",
           "type": "string",
           "format": "uri"
         }

--- a/src/test/java/org/folio/rest/impl/UserImportIT.java
+++ b/src/test/java/org/folio/rest/impl/UserImportIT.java
@@ -184,6 +184,7 @@ public class UserImportIT {
     then().
       statusCode(200).
       body("users[0].username", is("chani")).
+      body("users[0].personal.pronouns", is("He/Him")).
       body("users[0].customFields.classYear", startsWith("opt_"));
   }
 

--- a/src/test/resources/user-import.json
+++ b/src/test/resources/user-import.json
@@ -21,6 +21,7 @@
             "patronGroup": "graduate",
             "active": true,
             "personal": {
+                "pronouns": "He/Him",
                 "firstName": "Chani",
                 "lastName": "Kynes",
                 "preferredFirstName": "Sihaya"


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODUIMP-103

The new field personal.pronouns has been added to the user record for Sunflower:
* https://folio-org.atlassian.net/browse/MODUSERS-454
* https://folio-org.atlassian.net/browse/MODUSERS-505

This needs to be allowed in mod-user-import's user schema as well to be able to import that field.