### PR TITLE
MODUIMP-106: Allow displayInAccordion property in custom field

### DIFF
--- a/ramls/schemas/customField.json
+++ b/ramls/schemas/customField.json
@@ -77,6 +77,10 @@
       "$ref": "textField.json",
       "readonly": true
     },
+    "displayInAccordion": {
+      "type": "string",
+      "description": "Display in accordion names for the custom field"
+    },
     "metadata": {
       "description": "User metadata information",
       "$ref": "raml-util/schemas/metadata.schema",

--- a/src/test/resources/mock_user_creation_with_custom_fields.json
+++ b/src/test/resources/mock_user_creation_with_custom_fields.json
@@ -207,6 +207,7 @@
                 ]
               }
             },
+            "displayInAccordion": "Dep",
             "metadata": {
               "createdDate": "2020-01-27T09:47:05.247+0000",
               "createdByUserId": "7fb608d5-d252-5a3f-b36a-fa677dad4428",

--- a/src/test/resources/mock_user_creation_with_custom_fields.json
+++ b/src/test/resources/mock_user_creation_with_custom_fields.json
@@ -207,7 +207,7 @@
                 ]
               }
             },
-            "displayInAccordion": "Dep",
+            "displayInAccordion": "extended_information",
             "metadata": {
               "createdDate": "2020-01-27T09:47:05.247+0000",
               "createdByUserId": "7fb608d5-d252-5a3f-b36a-fa677dad4428",


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODUIMP-106

https://folio-org.atlassian.net/browse/FCFIELDS-54 has added displayInAccordion to custom fields for Trillium:
https://github.com/folio-org/folio-custom-fields/commit/d543228957c7e13e4ea8cacf076a7b6e7598b261

We need to accept this new property when fetching custom fields.