### PR TITLE
MODUIMP-115: Vert.x 4.5.25 fixing CVE-2025-67735 Netty CRLF injection

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -36,11 +36,11 @@
     <jsonschema_paths>schemas/**</jsonschema_paths>
     <generate_routing_context>/user-import</generate_routing_context>
 
-    <raml-module-builder-version>35.4.1</raml-module-builder-version>
+    <raml-module-builder-version>35.4.2</raml-module-builder-version>
     <lombok.version>1.18.36</lombok.version>
     <aspectj.version>1.9.22.1</aspectj.version>
     <jetbrains-annotations.version>26.0.2</jetbrains-annotations.version>
-    <vertx.version>4.5.13</vertx.version>
+    <vertx.version>4.5.25</vertx.version>
     <junit.version>4.13.2</junit.version>
     <rest-assured.version>5.5.1</rest-assured.version>
   </properties>


### PR DESCRIPTION
https://folio-org.atlassian.net/browse/MODUIMP-115
https://github.com/folio-org/raml-module-builder/releases/tag/v35.4.2